### PR TITLE
Changed app.pro, because by default I recieve compilation error: -lmodel...

### DIFF
--- a/defaults/app.pro
+++ b/defaults/app.pro
@@ -1,2 +1,3 @@
 TEMPLATE = subdirs
+CONFIG += ordered
 SUBDIRS = helpers models views controllers


### PR DESCRIPTION
Changed app.pro, because by default I recieve compilation error: -lmodel cannot find. Now fixed.
