### PR TITLE
Added named routes as an option

### DIFF
--- a/src/tactioncontroller.cpp
+++ b/src/tactioncontroller.cpp
@@ -25,6 +25,7 @@
 #include <TFormValidator>
 #include "tsessionmanager.h"
 #include "ttextview.h"
+#include "turlroute.h"
 
 #define FLASH_VARS_SESSION_KEY  "_flashVariants"
 #define LOGIN_USER_NAME_KEY     "_loginUserName"
@@ -869,6 +870,13 @@ void TActionController::closeWebSokcet(const QByteArray &uuid, int closeCode)
     info << uuid << closeCode;
     taskList << qMakePair((int)SendCloseTo, QVariant(info));
 }
+
+
+QString TActionController::route(const QByteArray &name, const std::vector<QVariant> &args) const
+{
+    return TUrlRoute::instance().findRouteByName(name).toPathString(args);
+}
+
 
 /*!
   \fn const TSession &TActionController::session() const;

--- a/src/tactioncontroller.h
+++ b/src/tactioncontroller.h
@@ -98,6 +98,7 @@ protected:
     void sendTextToWebSocket(const QByteArray &uuid, const QString &text);
     void sendBinaryToWebSocket(const QByteArray &uuid, const QByteArray &binary);
     void closeWebSokcet(const QByteArray &uuid, int closeCode = Tf::NormalClosure);
+    QString route(const QByteArray &name, const std::vector<QVariant> &args = std::vector<QVariant>()) const;
 
     virtual bool userLogin(const TAbstractUser *user);
     virtual void userLogout();

--- a/src/turlroute.h
+++ b/src/turlroute.h
@@ -27,9 +27,11 @@ public:
     QList<int>  keywordIndexes;
     QByteArray controller;
     QByteArray action;
+    QByteArray name;
     bool    hasVariableParams;
 
     TRoute() : method(Invalid), hasVariableParams(false) { }
+    QString toPathString(const std::vector<QVariant> &args = std::vector<QVariant>()) const;
 };
 
 
@@ -72,6 +74,7 @@ public:
     static const TUrlRoute &instance();
     static QStringList splitPath(const QString &path);
     TRouting findRouting(Tf::HttpMethod method, const QStringList &components) const;
+    TRoute findRouteByName(const QByteArray &pathName) const;
 
 protected:
     TUrlRoute() { }

--- a/src/tviewhelper.cpp
+++ b/src/tviewhelper.cpp
@@ -12,6 +12,7 @@
 #include <TAppSettings>
 #include <TActionView>
 #include <THttpUtility>
+#include "turlroute.h"
 
 
 /*!
@@ -644,6 +645,12 @@ QString TViewHelper::srcPath(const QString &src, const QString &dir, bool withTi
         }
     }
     return ret;
+}
+
+
+QString TViewHelper::route(const QByteArray &name, const std::vector<QVariant> &args) const
+{
+    return TUrlRoute::instance().findRouteByName(name).toPathString(args);
 }
 
 

--- a/src/tviewhelper.h
+++ b/src/tviewhelper.h
@@ -187,6 +187,8 @@ public:
 
     QString srcPath(const QString &src, const QString &dir, bool withTimestamp = false) const;
 
+    QString route(const QByteArray &name, const std::vector<QVariant> &args = std::vector<QVariant>()) const;
+
     THtmlAttribute a(const QString &key, const QString &value) const;
     THtmlAttribute a() const { return THtmlAttribute(); }
 


### PR DESCRIPTION
I have added support for named routes as an option.
for example

> GET    /book                                         Book#all                  allBooks
> GET    /book/:param                             Book#show             showBook
> GET    /another/no/name/route             Controller#action

doing anywhere in the **controller** or **view**

`route("allBooks");`

will return "/book"
and doing

`route("showBook", {1});`

will return "/book/1"
