### PR TITLE
Add valgrind error on mixing new[] and delete

### DIFF
--- a/src/tfileaiowriter_unix.cpp
+++ b/src/tfileaiowriter_unix.cpp
@@ -31,7 +31,7 @@ void TFileAioWriterData::clearSyncBuffer()
     if (!syncBuffer.isEmpty()) {
         for (QListIterator<struct aiocb *> it(syncBuffer); it.hasNext(); ) {
             struct aiocb *cb = it.next();
-            delete (char *)cb->aio_buf;
+            delete [] (char *) cb->aio_buf;
             delete cb;
         }
         syncBuffer.clear();


### PR DESCRIPTION
The array is allocated with new[] and needs to be deleted using
the delete[] operator.