### PR TITLE
Update configure script and Qt project for osx build.

### DIFF
--- a/configure
+++ b/configure
@@ -106,7 +106,8 @@ if [ "$KERNEL" = "Darwin" ]; then
   FRAMEWORK=/Library/Frameworks
   LIBDIR=$FRAMEWORK
   INCLUDEDIR=$FRAMEWORK/treefrog.framework/Headers
-  DATADIR=$FRAMEWORK/treefrog.framework/Share
+  DATADIR=$FRAMEWORK/treefrog.framework/Versions/Current/Supports/share
+  BINDIR=$FRAMEWORK/treefrog.framework/Versions/Current/Supports/bin
 else
   PREFIX=/usr
   BINDIR=$PREFIX/bin
@@ -147,7 +148,8 @@ while [ -n "`echo $1 | grep '-'`" ]; do
       FRAMEWORK=$optarg
       LIBDIR=$FRAMEWORK
       INCLUDEDIR=$FRAMEWORK/treefrog.framework/Headers
-      DATADIR=$FRAMEWORK/treefrog.framework/Share
+      DATADIR=$FRAMEWORK/treefrog.framework/Versions/Current/Supports/share
+      BINDIR=$FRAMEWORK/treefrog.framework/Versions/Current/Supports/bin
       ;;
     --enable-debug | --enable-debug=*)
       ENABLE_DEBUG=yes

--- a/tools/tfmanager/tfmanager.pro
+++ b/tools/tfmanager/tfmanager.pro
@@ -31,6 +31,7 @@ windows {
   }
 } else:macx {
   LIBS += -Wl,-rpath,$$lib.path -F$$lib.path -framework treefrog
+  QMAKE_RPATHDIR += @loader_path/../../../../../
 } else:unix {
   LIBS += -Wl,-rpath,$$lib.path -L$$lib.path -ltreefrog
 

--- a/tools/tfserver/tfserver.pro
+++ b/tools/tfserver/tfserver.pro
@@ -29,6 +29,7 @@ windows {
   LIBS += -L"$$target.path"
 } else:macx {
   LIBS += -Wl,-rpath,$$lib.path -F$$lib.path -framework treefrog
+  QMAKE_RPATHDIR += @loader_path/../../../../../
 } else:unix {
   LIBS += -Wl,-rpath,$$lib.path -L$$lib.path -ltreefrog
 

--- a/tools/tspawn/tspawn.pro
+++ b/tools/tspawn/tspawn.pro
@@ -28,6 +28,7 @@ windows {
   LIBS += -L"$$target.path"
 } else:macx {
   LIBS += -Wl,-rpath,$$lib.path -F$$lib.path -framework treefrog
+  QMAKE_RPATHDIR += @loader_path/../../../../../
 } else:unix {
   LIBS += -Wl,-rpath,$$lib.path -L$$lib.path -ltreefrog
 


### PR DESCRIPTION
I was fixed build script and framework structure on osx platform, in order to install under user directory.
Following is the structure of the framework.

```
treefrog.framework/Versions/Current/Supports/
    bin/
    share/
```

I think this framework configuration is a typical at osx.
It is verified that tutorial to work.
