### PR TITLE
Fixed crash on missing treefrog -k signal argument.

### DIFF
--- a/tools/tfmanager/main.cpp
+++ b/tools/tfmanager/main.cpp
@@ -451,6 +451,10 @@ int managerMain(int argc, char *argv[])
             break;
 
         case SendSignal:
+            if (!i.hasNext()) {
+                fprintf(stderr, "Missing signal name\n");
+                return 1;
+            }
             signalCmd = i.next(); // assign a command
             break;
 


### PR DESCRIPTION
QStringList::next() will lead to an out-of-range access
if the user forgot to specify the name of the signal
to be send.