### PR TITLE
Fix calling renderPartial() on Windows

### DIFF
--- a/src/tactionview.cpp
+++ b/src/tactionview.cpp
@@ -45,7 +45,7 @@ QString TActionView::renderPartial(const QString &templateName, const QVariantMa
 {
     QString temp = templateName;
     if (!temp.contains('/')) {
-        temp = QLatin1String("partial") + QDir::separator() + temp;
+        temp = QLatin1String("partial/") + temp;
     }
     return (actionController) ? actionController->getRenderingData(temp, vars) : QString();
 }


### PR DESCRIPTION
If you call renderPartial("foo") on Windows, this did not work and
resulted in the error

    Invalid patameter: partial\foo

in the logs. The problem is that TActionController::getRenderingData()
splits the template name at the "/" character. But the
TActionView::renderPartial() function used QDir::separator() as a
separator (i.e. the "\" character on Windows).

So either TActionController::getRenderingData() or
TActionView::renderPartial() needs to be fixed, so that both functions
use the same character.

Fixing TActionView::renderPartial() seems to be the better choice for
the fix since the template could not only use

    renderPartial("foo")

but also

    renderPartial("partial/foo")

or

    renderPartial("bar/foo")

So the template files that call renderPartial() should be
cross-platform, so using "/" on Windows should be supported. (And the
code in TActionController::getRenderingData() already works for this as
it is.)