### PR TITLE
parse application/xml or text/xml to formItems

### DIFF
--- a/src/thttprequest.cpp
+++ b/src/thttprequest.cpp
@@ -342,6 +342,11 @@ void THttpRequest::parseBody(const QByteArray &body, const THttpRequestHeader &h
             d->multipartFormData = TMultipartFormData(body, boundary());
             d->formItems = d->multipartFormData.formItems();
 
+        } else if (ctype.startsWith("text/xml", Qt::CaseInsensitive)) {
+            static QString key("xml");
+            QString val = QString::fromUtf8(body.constData(), body.length());
+            d->formItems.insertMulti(key, val);
+            tSystemDebug("POST Hash << %s : %s", qPrintable(key), qPrintable(val));
         } else if (ctype.startsWith("application/json", Qt::CaseInsensitive)) {
 #if QT_VERSION >= 0x050000
             QJsonParseError error;

--- a/src/thttprequest.cpp
+++ b/src/thttprequest.cpp
@@ -342,7 +342,7 @@ void THttpRequest::parseBody(const QByteArray &body, const THttpRequestHeader &h
             d->multipartFormData = TMultipartFormData(body, boundary());
             d->formItems = d->multipartFormData.formItems();
 
-        } else if (ctype.startsWith("text/xml", Qt::CaseInsensitive)) {
+        } else if (ctype.startsWith("application/xml", Qt::CaseInsensitive)) {
             static QString key("xml");
             QString val = QString::fromUtf8(body.constData(), body.length());
             d->formItems.insertMulti(key, val);

--- a/src/thttputility.cpp
+++ b/src/thttputility.cpp
@@ -312,6 +312,17 @@ QString THttpUtility::fromMimeEncoded(const QByteArray &mime)
 }
 
 /*!
+  Returns a decoded copy of the \a charset encoded array \a data.
+*/
+QString THttpUtility::fromCharSetEncoded(const QString &charset, const QByteArray &data)
+{
+    QTextCodec* codec = QTextCodec::codecForName(charset.toStdString().c_str());
+    if (!codec)
+        codec = QTextCodec::codecForName("UTF-8");
+    return codec->toUnicode(data);
+}
+
+/*!
   Returns a reason phrase of the HTTP status code \a statusCode.
 */
 QByteArray THttpUtility::getResponseReasonPhrase(int statusCode)

--- a/src/thttputility.h
+++ b/src/thttputility.h
@@ -27,6 +27,7 @@ public:
     static QByteArray toMimeEncoded(const QString &input, const QByteArray &encoding = "UTF-8");
     static QByteArray toMimeEncoded(const QString &input, QTextCodec *codec);
     static QString fromMimeEncoded(const QByteArray &mime);
+    static QString fromCharSetEncoded(const QString &charset, const QByteArray &data);
     static QByteArray getResponseReasonPhrase(int statusCode);
     static QString trimmedQuotes(const QString &string);
     static QByteArray timeZone();


### PR DESCRIPTION
Currently no way to access post xml data in http request.  This code just parse application/xml or text/xml into formItems with key "xml"
The xml will be decoded with encoding declared in charset, or UTF-8 by default