### PR TITLE
Fixed risky fallback for Content-Type in POST handling.

### DIFF
--- a/src/thttprequest.cpp
+++ b/src/thttprequest.cpp
@@ -353,8 +353,7 @@ void THttpRequest::parseBody(const QByteArray &body, const THttpRequestHeader &h
 #else
             tSystemWarn("unsupported content-type: %s", qPrintable(ctype));
 #endif
-        } else {
-            // 'application/x-www-form-urlencoded'
+        } else if (ctype.startsWith("application/x-www-form-urlencoded", Qt::CaseInsensitive)) {
             if (!body.isEmpty()) {
                 const QList<QByteArray> formdata = body.split('&');
                 for (auto &frm : formdata) {
@@ -368,6 +367,8 @@ void THttpRequest::parseBody(const QByteArray &body, const THttpRequestHeader &h
                     }
                 }
             }
+        } else {
+            tSystemWarn("unsupported content-type: %s", qPrintable(ctype));
         }
         /* FALL THROUGH */ }
 


### PR DESCRIPTION
The HTML spec talks about multipart/form-data and
application/x-www-form-urlencoded content-types only. But I see
there's support for application/json, too. And my
client based on QHttpMultiPart was sending multipart/mixed. This
may have been wrong but better diagnostics helped finding the
configuration problem.