### PR TITLE
Handle quoted multipart/form-data boundary value.

### DIFF
--- a/src/thttprequest.cpp
+++ b/src/thttprequest.cpp
@@ -408,8 +408,12 @@ QByteArray THttpRequest::boundary() const
         for (auto &bnd : lst) {
             QString string = bnd.trimmed();
             if (string.startsWith("boundary=", Qt::CaseInsensitive)) {
-                boundary  = "--";
-                boundary += string.mid(9).toLatin1();
+                boundary = string.mid(9).toLatin1();
+                // strip optional surrounding quotes (RFC 2046 and 7578)
+                if (boundary.startsWith('"') && boundary.endsWith('"')) {
+                    boundary = boundary.mid(1, boundary.size() - 2);
+                }
+                boundary.prepend("--");
                 break;
             }
         }


### PR DESCRIPTION
I don't expect a Web browser to ever quote the boundary value
as they can just stick to a simple character set. But clients
may behave differently when performing REST calls for example.

No signs of quotes in grammar of the old RFC1521. But RFC2046
says "it does not hurt" and RFC7578 (referenced by the HTML 5
W3C standard) emphasises that "it is often necessary".

Ran into this scenario when using QtNetwork's QHttpMultiPart
class for a command line client.