### PR TITLE
github page search.html: update tipue script search result links

### DIFF
--- a/docs/assets/js/tipuesearch.js
+++ b/docs/assets/js/tipuesearch.js
@@ -1,14 +1,9 @@
----
----   
-
 /*
 Tipue Search 6.0
 Copyright (c) 2017 Tipue
 Tipue Search is released under the MIT License
 http://www.tipue.com/search
 */
-
-var SITEBASE_URL = "{{ site.baseurl }}";
 
 (function($) {
 
@@ -22,6 +17,7 @@ var SITEBASE_URL = "{{ site.baseurl }}";
           'contextStart'           : 90,
           'debug'                  : false,
           'descriptiveWords'       : 25,
+          'githubPageBaseUrl'      : '',
           'highlightTerms'         : true,
           'liveContent'            : '*',
           'liveDescription'        : '*',
@@ -377,7 +373,7 @@ var SITEBASE_URL = "{{ site.baseurl }}";
                               {
                                    if (l_o >= start && l_o < set.show + start)
                                    {                                   
-                                        out += '<div class="tipue_search_content_title"><a href="' + SITEBASE_URL + found[i].url + '"' + tipue_search_w + '>' +  found[i].title + '</a></div>';
+                                        out += '<div class="tipue_search_content_title"><a href="' + set.githubPageBaseUrl + found[i].url + '"' + tipue_search_w + '>' +  found[i].title + '</a></div>';
  
                                         if (set.debug)
                                         {                                             
@@ -391,7 +387,7 @@ var SITEBASE_URL = "{{ site.baseurl }}";
                                              {
                                                   s_u = s_u.slice(7);
                                              }                                             
-                                             out += '<div class="tipue_search_content_url"><a href="' + SITEBASE_URL + found[i].url + '"' + tipue_search_w + '>' + s_u + '</a></div>';
+                                             out += '<div class="tipue_search_content_url"><a href="' + set.githubPageBaseUrl + found[i].url + '"' + tipue_search_w + '>' + s_u + '</a></div>';
                                         }
                                         
                                         if (found[i].desc)

--- a/docs/assets/js/tipuesearch.js
+++ b/docs/assets/js/tipuesearch.js
@@ -1,3 +1,5 @@
+---
+---   
 
 /*
 Tipue Search 6.0
@@ -6,6 +8,7 @@ Tipue Search is released under the MIT License
 http://www.tipue.com/search
 */
 
+var SITEBASE_URL = "{{ site.baseurl }}";
 
 (function($) {
 
@@ -374,7 +377,7 @@ http://www.tipue.com/search
                               {
                                    if (l_o >= start && l_o < set.show + start)
                                    {                                   
-                                        out += '<div class="tipue_search_content_title"><a href="' + found[i].url + '"' + tipue_search_w + '>' +  found[i].title + '</a></div>';
+                                        out += '<div class="tipue_search_content_title"><a href="' + SITEBASE_URL + found[i].url + '"' + tipue_search_w + '>' +  found[i].title + '</a></div>';
  
                                         if (set.debug)
                                         {                                             
@@ -388,7 +391,7 @@ http://www.tipue.com/search
                                              {
                                                   s_u = s_u.slice(7);
                                              }                                             
-                                             out += '<div class="tipue_search_content_url"><a href="' + found[i].url + '"' + tipue_search_w + '>' + s_u + '</a></div>';
+                                             out += '<div class="tipue_search_content_url"><a href="' + SITEBASE_URL + found[i].url + '"' + tipue_search_w + '>' + s_u + '</a></div>';
                                         }
                                         
                                         if (found[i].desc)

--- a/docs/assets/js/tipuesearch.min.js
+++ b/docs/assets/js/tipuesearch.min.js
@@ -1,6 +1,4 @@
----
----   
-var SITEBASE_URL = "{{ site.baseurl }}";(function($){$.fn.tipuesearch=function(options){var set=$.extend({'contentLocation':'tipuesearch/tipuesearch_content.json','contextBuffer':60,'contextLength':60,'contextStart':90,'debug':false,'descriptiveWords':25,'highlightTerms':true,'liveContent':'*','liveDescription':'*','minimumLength':3,'mode':'static','newWindow':false,'show':9,'showContext':true,'showRelated':true,'showTime':true,'showTitleCount':true,'showURL':true,'wholeWords':true},options);return this.each(function(){var tipuesearch_in={pages:[]};$.ajaxSetup({async:false});var tipuesearch_t_c=0;$('#tipue_search_content').hide().html('<div class="tipue_search_spinner"><div class="tipue_search_rect1"></div><div class="tipue_search_rect2"></div><div class="rect3"></div></div>').show();if(set.mode=='live')
+(function($){$.fn.tipuesearch=function(options){var set=$.extend({'contentLocation':'tipuesearch/tipuesearch_content.json','contextBuffer':60,'contextLength':60,'contextStart':90,'debug':false,'descriptiveWords':25,'githubPageBaseUrl':'','highlightTerms':true,'liveContent':'*','liveDescription':'*','minimumLength':3,'mode':'static','newWindow':false,'show':9,'showContext':true,'showRelated':true,'showTime':true,'showTitleCount':true,'showURL':true,'wholeWords':true},options);return this.each(function(){var tipuesearch_in={pages:[]};$.ajaxSetup({async:false});var tipuesearch_t_c=0;$('#tipue_search_content').hide().html('<div class="tipue_search_spinner"><div class="tipue_search_rect1"></div><div class="tipue_search_rect2"></div><div class="rect3"></div></div>').show();if(set.mode=='live')
 {for(var i=0;i<tipuesearch_pages.length;i++)
 {$.get(tipuesearch_pages[i]).done(function(html)
 {var cont=$(set.liveContent,html).text();cont=cont.replace(/\s+/g,' ');var desc=$(set.liveDescription,html).text();desc=desc.replace(/\s+/g,' ');var t_1=html.toLowerCase().indexOf('<title>');var t_2=html.toLowerCase().indexOf('</title>',t_1+7);if(t_1!=-1&&t_2!=-1)
@@ -102,12 +100,12 @@ if(set.showTime)
 {var endTimer=new Date().getTime();var time=(endTimer-startTimer)/ 1000;out+=' ('+time.toFixed(2)+' '+tipuesearch_string_14+')';set.showTime=false;}
 out+='</div>';found.sort(function(a,b){return b.score-a.score});var l_o=0;for(var i=0;i<found.length;i++)
 {if(l_o>=start&&l_o<set.show+start)
-{out+='<div class="tipue_search_content_title"><a href="'+SITEBASE_URL+found[i].url+'"'+tipue_search_w+'>'+found[i].title+'</a></div>';if(set.debug)
+{out+='<div class="tipue_search_content_title"><a href="'+set.githubPageBaseUrl+found[i].url+'"'+tipue_search_w+'>'+found[i].title+'</a></div>';if(set.debug)
 {out+='<div class="tipue_search_content_debug">Score: '+found[i].score+'</div>';}
 if(set.showURL)
 {var s_u=found[i].url.toLowerCase();if(s_u.indexOf('http://')==0)
 {s_u=s_u.slice(7);}
-out+='<div class="tipue_search_content_url"><a href="'+SITEBASE_URL+found[i].url+'"'+tipue_search_w+'>'+s_u+'</a></div>';}
+out+='<div class="tipue_search_content_url"><a href="'+set.githubPageBaseUrl+found[i].url+'"'+tipue_search_w+'>'+s_u+'</a></div>';}
 if(found[i].desc)
 {var t=found[i].desc;if(set.showContext)
 {d_w=d.split(' ');var s_1=found[i].desc.toLowerCase().indexOf(d_w[0]);if(s_1>set.contextStart)

--- a/docs/assets/js/tipuesearch.min.js
+++ b/docs/assets/js/tipuesearch.min.js
@@ -1,4 +1,6 @@
-(function($){$.fn.tipuesearch=function(options){var set=$.extend({'contentLocation':'tipuesearch/tipuesearch_content.json','contextBuffer':60,'contextLength':60,'contextStart':90,'debug':false,'descriptiveWords':25,'highlightTerms':true,'liveContent':'*','liveDescription':'*','minimumLength':3,'mode':'static','newWindow':false,'show':9,'showContext':true,'showRelated':true,'showTime':true,'showTitleCount':true,'showURL':true,'wholeWords':true},options);return this.each(function(){var tipuesearch_in={pages:[]};$.ajaxSetup({async:false});var tipuesearch_t_c=0;$('#tipue_search_content').hide().html('<div class="tipue_search_spinner"><div class="tipue_search_rect1"></div><div class="tipue_search_rect2"></div><div class="rect3"></div></div>').show();if(set.mode=='live')
+---
+---   
+var SITEBASE_URL = "{{ site.baseurl }}";(function($){$.fn.tipuesearch=function(options){var set=$.extend({'contentLocation':'tipuesearch/tipuesearch_content.json','contextBuffer':60,'contextLength':60,'contextStart':90,'debug':false,'descriptiveWords':25,'highlightTerms':true,'liveContent':'*','liveDescription':'*','minimumLength':3,'mode':'static','newWindow':false,'show':9,'showContext':true,'showRelated':true,'showTime':true,'showTitleCount':true,'showURL':true,'wholeWords':true},options);return this.each(function(){var tipuesearch_in={pages:[]};$.ajaxSetup({async:false});var tipuesearch_t_c=0;$('#tipue_search_content').hide().html('<div class="tipue_search_spinner"><div class="tipue_search_rect1"></div><div class="tipue_search_rect2"></div><div class="rect3"></div></div>').show();if(set.mode=='live')
 {for(var i=0;i<tipuesearch_pages.length;i++)
 {$.get(tipuesearch_pages[i]).done(function(html)
 {var cont=$(set.liveContent,html).text();cont=cont.replace(/\s+/g,' ');var desc=$(set.liveDescription,html).text();desc=desc.replace(/\s+/g,' ');var t_1=html.toLowerCase().indexOf('<title>');var t_2=html.toLowerCase().indexOf('</title>',t_1+7);if(t_1!=-1&&t_2!=-1)
@@ -100,12 +102,12 @@ if(set.showTime)
 {var endTimer=new Date().getTime();var time=(endTimer-startTimer)/ 1000;out+=' ('+time.toFixed(2)+' '+tipuesearch_string_14+')';set.showTime=false;}
 out+='</div>';found.sort(function(a,b){return b.score-a.score});var l_o=0;for(var i=0;i<found.length;i++)
 {if(l_o>=start&&l_o<set.show+start)
-{out+='<div class="tipue_search_content_title"><a href="'+found[i].url+'"'+tipue_search_w+'>'+found[i].title+'</a></div>';if(set.debug)
+{out+='<div class="tipue_search_content_title"><a href="'+SITEBASE_URL+found[i].url+'"'+tipue_search_w+'>'+found[i].title+'</a></div>';if(set.debug)
 {out+='<div class="tipue_search_content_debug">Score: '+found[i].score+'</div>';}
 if(set.showURL)
 {var s_u=found[i].url.toLowerCase();if(s_u.indexOf('http://')==0)
 {s_u=s_u.slice(7);}
-out+='<div class="tipue_search_content_url"><a href="'+found[i].url+'"'+tipue_search_w+'>'+s_u+'</a></div>';}
+out+='<div class="tipue_search_content_url"><a href="'+SITEBASE_URL+found[i].url+'"'+tipue_search_w+'>'+s_u+'</a></div>';}
 if(found[i].desc)
 {var t=found[i].desc;if(set.showContext)
 {d_w=d.split(' ');var s_1=found[i].desc.toLowerCase().indexOf(d_w[0]);if(s_1>set.contextStart)

--- a/docs/assets/js/tipuesearch_set.js
+++ b/docs/assets/js/tipuesearch_set.js
@@ -54,7 +54,7 @@ var tipuesearch_related = {'searches': [
 
 // Internal strings
 
-if (language == "jp") {
+if (language == "ja") {
     var tipuesearch_string_1 = 'タイトルなし';
     var tipuesearch_string_2 = '検索結果を表示: ';
     var tipuesearch_string_3 = '代わりに検索: ';

--- a/docs/search.html
+++ b/docs/search.html
@@ -14,6 +14,14 @@ layout: default
 </script>
 <script src="{{ site.baseurl }}/assets/js/tipuesearch_set.js"></script>
 <script src="{{ site.baseurl }}/assets/js/tipuesearch.min.js"></script>
+<script>
+$(document).ready(function() {
+     $('#tipue_search_input').tipuesearch({
+          'githubPageBaseUrl': '{{ site.baseurl }}',
+          'showTitleCount': false
+     });
+});
+</script>
 
 <form action="{{ site.baseurl }}/search.html" id="search-form" method="get">
     <input type="text" name="q" id="tipue_search_input" class="search-box" placeholder="Search...">


### PR DESCRIPTION
- added "site.baseurl" to search result links (for headline and url), otherwise target page would not be found when once clicked