### PR TITLE
Github Pages Search Link Bugfix

### DIFF
--- a/docs/_includes/search_json.html
+++ b/docs/_includes/search_json.html
@@ -22,12 +22,9 @@
 
 <script>
 $(document).ready(function() {
-    $('#tipue_search_input').tipuesearch({
-        'mode': 'static',
-        'show': 10,
-        'newWindow': false,
-        'minimumLength': 2,
-        'wholeWords': false
-    });
+     $('#tipue_search_input').tipuesearch({
+          'githubPageBaseUrl': '{{ site.baseurl }}',
+          'showTitleCount': false
+     });
 });
 </script>

--- a/docs/search.html
+++ b/docs/search.html
@@ -14,14 +14,6 @@ layout: default
 </script>
 <script src="{{ site.baseurl }}/assets/js/tipuesearch_set.js"></script>
 <script src="{{ site.baseurl }}/assets/js/tipuesearch.min.js"></script>
-<script>
-$(document).ready(function() {
-     $('#tipue_search_input').tipuesearch({
-          'githubPageBaseUrl': '{{ site.baseurl }}',
-          'showTitleCount': false
-     });
-});
-</script>
 
 <form action="{{ site.baseurl }}/search.html" id="search-form" method="get">
     <input type="text" name="q" id="tipue_search_input" class="search-box" placeholder="Search...">


### PR DESCRIPTION
bugfix: removed unused left over tipue search initialisation which caused a double initialisation and therefore deleted the previous initial initialisation with options

** result successfully tested **