### PR TITLE
Changed tmake, do not auto include all helper headers

### DIFF
--- a/tools/tmake/erbconverter.cpp
+++ b/tools/tmake/erbconverter.cpp
@@ -41,8 +41,8 @@
 const QRegExp RxPartialTag("<%#partial[ \t]+\"([^\"]+)\"[ \t]*%>");
 
 
-ErbConverter::ErbConverter(const QDir &output, const QDir &helpers, const QDir &partial)
-    : outputDirectory(output), helpersDirectory(helpers), partialDirectory(partial)
+ErbConverter::ErbConverter(const QDir &output, const QDir &partial)
+    : outputDirectory(output), partialDirectory(partial)
 { }
 
 
@@ -147,13 +147,6 @@ QString ErbConverter::escapeNewline(const QString &string)
 QString ErbConverter::generateIncludeCode(const ErbParser &parser) const
 {
     QString code = parser.includeCode();
-    QStringList filter;
-    filter << "*.h" << "*.hh" << "*.hpp" << "*.hxx";
-    foreach (QString f, helpersDirectory.entryList(filter, QDir::Files)) {
-        code += "#include \"";
-        code += f;
-        code += "\"\n";
-    }
     return code;
 }
 

--- a/tools/tmake/erbconverter.h
+++ b/tools/tmake/erbconverter.h
@@ -11,7 +11,7 @@ class ErbParser;
 class ErbConverter
 {
 public:
-    ErbConverter(const QDir &output, const QDir &helpers, const QDir &partial);
+    ErbConverter(const QDir &output, const QDir &partial);
     bool convert(const QString &erbPath, int trimMode) const;
     bool convert(const QString &className, const QString &erb, int trimMode) const;
     QDir outputDir() const { return outputDirectory; }
@@ -24,7 +24,6 @@ protected:
 
 private:
     QDir outputDirectory;
-    QDir helpersDirectory;
     QDir partialDirectory;
 };
 

--- a/tools/tmake/otamaconverter.cpp
+++ b/tools/tmake/otamaconverter.cpp
@@ -68,8 +68,8 @@ QString generateErbPhrase(const QString &str, int echoOption)
 }
 
 
-OtamaConverter::OtamaConverter(const QDir &output, const QDir &helpers, const QDir &partial)
-    : erbConverter(output, helpers, partial)
+OtamaConverter::OtamaConverter(const QDir &output, const QDir &partial)
+    : erbConverter(output, partial)
 { }
 
 

--- a/tools/tmake/otamaconverter.h
+++ b/tools/tmake/otamaconverter.h
@@ -10,7 +10,7 @@
 class OtamaConverter
 {
 public:
-    OtamaConverter(const QDir &output, const QDir &helpers, const QDir &partial);
+    OtamaConverter(const QDir &output, const QDir &partial);
     ~OtamaConverter();
 
     bool convert(const QString &filePath, int trimMode) const;

--- a/tools/tmake/viewconverter.cpp
+++ b/tools/tmake/viewconverter.cpp
@@ -51,14 +51,11 @@ int ViewConverter::convertView(const QString &templateSystem) const
     QStringList classList;
     QStringList viewFiles;
 
-    QDir helpersDir = viewDir;
-    helpersDir.cdUp();
-    helpersDir.cd("helpers");
     QDir partialDir = viewDir;
     partialDir.cd("partial");
 
-    ErbConverter erbconv(outputDir, helpersDir, partialDir);
-    OtamaConverter otamaconv(outputDir, helpersDir, partialDir);
+    ErbConverter erbconv(outputDir, partialDir);
+    OtamaConverter otamaconv(outputDir, partialDir);
 
     for (const QString &d : viewDir.entryList(QDir::Dirs | QDir::NoDotAndDotDot)) {
         // Reads erb-files


### PR DESCRIPTION
If you want to add some helper headers to your view files, manually add them to the specific erb/otama files.
Let other view files clean without  unneccessary include headers.