### PR TITLE
TextCodec for reading user's config file

### DIFF
--- a/src/twebapplication.cpp
+++ b/src/twebapplication.cpp
@@ -476,6 +476,7 @@ const QVariantMap &TWebApplication::getConfig(const QString &configName)
                     // INI format
                     QVariantMap map;
                     QSettings settings(fi.absoluteFilePath(), QSettings::IniFormat);
+					settings.setIniCodec(codecInternal);
                     for (auto &k : (const QStringList &)settings.allKeys()) {
                         map.insert(k, settings.value(k));
                     }
@@ -487,7 +488,8 @@ const QVariantMap &TWebApplication::getConfig(const QString &configName)
                     // JSON format
                     QFile jsonFile(fi.absoluteFilePath());
                     if (jsonFile.open(QIODevice::ReadOnly)) {
-                        auto json = QJsonDocument::fromJson(jsonFile.readAll()).object();
+						QString data = codecInternal->toUnicode(jsonFile.readAll());
+                        auto json = QJsonDocument::fromJson(data.toLatin1()).object();
                         jsonFile.close();
                         configMap.insert(cnf, json.toVariantMap());
                         break;


### PR DESCRIPTION
If we defined some other settings files encoded with UTF-8,  and use Tf::app()->getConfigValue() method get some values,  apply toString() method to these values, webpage can't show them correctly.
So I use application.ini --InternalEncoding to decode these user's config value.