### PR TITLE
Fix line endings of HTTP headers on Windows

### DIFF
--- a/src/tinternetmessageheader.cpp
+++ b/src/tinternetmessageheader.cpp
@@ -9,11 +9,7 @@
 #include "tsystemglobal.h"
 #include "thttputility.h"
 
-#ifdef Q_OS_WIN
-#define CRLF "\n"
-#else
 #define CRLF "\r\n"
-#endif
 
 /*!
   \class TInternetMessageHeader


### PR DESCRIPTION
HTTP headers should always use CRLF line endigs. Ensure that is done on
Windows as well. This define is used in the toByteArray() function. So
this is supposed to return the raw byte data. And as far as I can tell,
this raw data is always written to binary devices (i.e. no line ending
conversions are done).

I noticed this problem when running a Treefrog server on Windows with a
web socket. And when trying to access this web socket with QWebSocket
(from Qt 5.7.0 -- I havent tried another Qt version), it always resulted
in an error

    QWebSocketPrivate::processHandshake: Connection closed while reading header.

And this is because the "Switching Protocols" reply uses just LF for
terminating the HTTP header fields. But the problem is not limited to
this reply, I see in Wireshark that "normal" HTTP replies also use LF
instead of CRLF. (It just seems that most clients are more permissive
than QWebSocket.)