### PR TITLE
"Accept-Range" Supported! 

### DIFF
--- a/src/tactioncontext.cpp
+++ b/src/tactioncontext.cpp
@@ -292,10 +292,9 @@ void TActionContext::execute(THttpRequest &request, int sid)
                         Tf::HttpStatusCode statusCode = Tf::OK;
                         if(range != QByteArray()){
                             statusCode = Tf::PartialContent;//Note:If Range is not NULL,statusCode will be 206
-                            qint64 size = reqPath.size();
                             range.replace("="," ");
                             range = range.endsWith("-") ? range.append(QByteArray::number(reqPath.size() - 1)) : range;
-                            QByteArray content_range = QString("%0/%1").arg(QString(range)).arg(size).toUtf8();
+                            QByteArray content_range =  range.append("/").append(QByteArray::number(reqPath.size()));
                             responseHeader.setRawHeader("Content-Range", content_range);
                             responseHeader.setRawHeader("Accept-Ranges", "bytes");
                         }

--- a/src/thttpsocket.cpp
+++ b/src/thttpsocket.cpp
@@ -79,7 +79,7 @@ QList<THttpRequest> THttpSocket::read()
 }
 
 
-qint64 THttpSocket::write(THttpHeader *header, QIODevice *body)
+qint64 THttpSocket::write(const THttpHeader *header, QIODevice *body)
 {
     T_TRACEFUNC("");
 
@@ -91,29 +91,21 @@ qint64 THttpSocket::write(THttpHeader *header, QIODevice *body)
     }
 
     qint64 pos_begin = 0;
-    qint64 pos_end = -1;
-    qint64 content_length = header->rawHeader("Content-Length").toLongLong();
+    qint64 content_length = header->rawHeader("Content-Length").toLongLong();//Gain the Content-Length
 
-    if(body){
-        pos_end = body->size() - 1;
-        QByteArray content_range = header->rawHeader("Content-Range");
-        if(content_range != QByteArray()){
-            QStringList content_range_parts = QString(content_range).split(" ");
-            if(content_range_parts.count() >= 2){
-                QStringList range_parts =  content_range_parts.at(1).split("/");
-                if(range_parts.count() >= 2){
-                    QStringList begin_end_parts = range_parts.at(0).split("-");
-                    if(begin_end_parts.count() >= 2){
-                        pos_begin = begin_end_parts.at(0).toLongLong();
-                        pos_end = begin_end_parts.at(1).toLongLong();
-                        content_length = pos_end - pos_begin + 1;
-                    }
+    QByteArray content_range = header->rawHeader("Content-Range");
+    if(content_range != QByteArray()){
+        QStringList content_range_parts = QString(content_range).split(" ");
+        if(content_range_parts.count() >= 2){
+            QStringList range_parts =  content_range_parts.at(1).split("/");
+            if(range_parts.count() >= 2){
+                QStringList begin_end_parts = range_parts.at(0).split("-");
+                if(begin_end_parts.count() >= 2){
+                    pos_begin = begin_end_parts.at(0).toLongLong();//Gain the Position Begin
                 }
             }
         }
     }
-
-    header->setContentLength(content_length);
 
     // Writes HTTP header
     QByteArray hdata = header->toByteArray();

--- a/src/thttpsocket.h
+++ b/src/thttpsocket.h
@@ -20,7 +20,7 @@ public:
 
     QList<THttpRequest> read();
     bool canReadRequest() const;
-    qint64 write(const THttpHeader *header, QIODevice *body);
+    qint64 write(THttpHeader *header, QIODevice *body);
     int idleTime() const;
     int socketId() const { return sid; }
     void deleteLater();

--- a/src/thttpsocket.h
+++ b/src/thttpsocket.h
@@ -20,7 +20,7 @@ public:
 
     QList<THttpRequest> read();
     bool canReadRequest() const;
-    qint64 write(THttpHeader *header, QIODevice *body);
+    qint64 write(const THttpHeader *header, QIODevice *body);
     int idleTime() const;
     int socketId() const { return sid; }
     void deleteLater();


### PR DESCRIPTION
When the static resource requested which in public directory，a full content-lenght request will get the file successed，but server might not reponse quite be what you expect when a static resource request with a header "Ranges:bytes=xxx-yy".
In addition，for example ，a Android MediaPlayer，when Android Player play the http resource in public dir just like  .mpg/.mp4/.mp3, usually ,the player request data with a header "Ranges", but server is not supported,so,player will not get the expected data，a error occurred.
So i fixed the problem!