### PR TITLE
Support SMTP connections to older servers not supporting ESMTP yet

### DIFF
--- a/src/tsmtpmailer.cpp
+++ b/src/tsmtpmailer.cpp
@@ -171,9 +171,11 @@ bool TSmtpMailer::send()
     }
 
     if (!cmdEhlo()) {
-        tSystemError("SMTP: EHLO Command Failed");
-        cmdQuit();
-        return false;
+        if (!cmdHelo()) {
+            tSystemError("SMTP: HELO/EHLO Command Failed");
+            cmdQuit();
+            return false;
+        }
     }
 
     if (tlsEnable && tlsAvailable) {
@@ -263,6 +265,24 @@ bool TSmtpMailer::cmdEhlo()
             tlsAvailable = true;
         }
     }
+    return true;
+}
+
+
+bool TSmtpMailer::cmdHelo()
+{
+    QByteArray helo;
+    helo.append("HELO [");
+    helo.append(qPrintable(socket->localAddress().toString()));
+    helo.append("]");
+
+    QList<QByteArray> reply;
+    if (cmd(helo, &reply) != 250) {
+        return false;
+    }
+
+    tlsAvailable = false;
+    authEnable = false;
     return true;
 }
 

--- a/src/tsmtpmailer.h
+++ b/src/tsmtpmailer.h
@@ -50,6 +50,7 @@ protected:
     bool send();
     bool connectToHost(const QString &hostName, quint16 port);
     bool cmdEhlo();
+    bool cmdHelo();
     bool cmdStartTls();
     bool cmdAuth();
     bool cmdRset();


### PR DESCRIPTION
This adjusts the initial SMTP handshake performed by Treefrog such
that in case EHLO fails, it'll fall back to HELO (and also avoid using
other ESMTP commands such as STARTTLS or AUTH). This is per the
recommendation in RFC 1869 which says that

> In the case of any error response, the client SMTP should issue either
the HELO or QUIT command.

This enables Treefrog to talk to older or very primitive SMTP servers
not supporting ESMTP. In particular, it allows using the
'DebuggingServer' class which is part of the 'smtp' module shipped with
Python. This makes writing tests for applications built using Treefrog quite
a bit easier, because one can simply run

```
python -m smtpd -c DebuggingServer -n
```

to start an SMTP server which prints all mail received to stdout, and then instruct Teamserver to talk to the SMTP server localhost:8025.