### PR TITLE
Use delete[] to free aio_buf in aiocb struct

### DIFF
--- a/src/tfileaiologger_unix.cpp
+++ b/src/tfileaiologger_unix.cpp
@@ -27,7 +27,7 @@ public:
 void TFileAioLoggerData::clearSyncBuffer()
 {
     for (auto cb : (const List<struct aiocb*> &)syncBuffer) {
-        delete (char *)cb->aio_buf;
+        delete[] (char *)cb->aio_buf;
         delete cb;
     }
     syncBuffer.clear();
@@ -119,7 +119,7 @@ void TFileAioLogger::log(const QByteArray &msg)
 
     if (tf_aio_write(cb) < 0) {
         tSystemError("log write failed");
-        delete (char *)cb->aio_buf;
+        delete[] (char *)cb->aio_buf;
         delete cb;
 
         close();

--- a/src/tfileaiowriter_unix.cpp
+++ b/src/tfileaiowriter_unix.cpp
@@ -127,7 +127,7 @@ int TFileAioWriter::write(const char *data, int length)
     if (ret < 0) {
         //fprintf(stderr, "aio_write error fd:%d (pid:%d tid:%d) ret:%d errno:%d\n", d->fileDescriptor, getpid(), gettid(), ret, err);
         //fprintf(stderr, "aio_write str: %s\n", data);
-        delete (char *)cb->aio_buf;
+        delete[] (char *)cb->aio_buf;
         delete cb;
 
         if (err != EAGAIN) {

--- a/src/tfileaiowriter_win.cpp
+++ b/src/tfileaiowriter_win.cpp
@@ -32,11 +32,10 @@ public:
     void clearSyncBuffer();
 };
 
-
 void TFileAioWriterData::clearSyncBuffer()
 {
     for (auto ab : (const QList<aiobuf_t *> &)syncBuffer) {
-        delete (char *)ab->aio_buf;
+        delete[] (char *)ab->aio_buf;
         delete ab;
     }
     syncBuffer.clear();
@@ -138,7 +137,7 @@ int TFileAioWriter::write(const char *data, int length)
     BOOL res = WriteFile(d->fileHandle, ab->aio_buf, (DWORD)len, NULL, &ab->aio_overlap);
     if (!res && GetLastError() != ERROR_IO_PENDING) {
         //fprintf(stderr, "WriteFile error str: %s\n", data);
-        delete (char *)ab->aio_buf;
+        delete[] (char *)ab->aio_buf;
         delete ab;
 
         close();


### PR DESCRIPTION
ab->aio_buf is an array, so it must be released using delete[] not delete.
This was probably a memory leak.
