### PR TITLE
Override std::exception what() method and return correct error message

### DIFF
--- a/src/tfexception.cpp
+++ b/src/tfexception.cpp
@@ -1,6 +1,58 @@
 #include "tfexception.h"
 
 /*!
+  \class TfException
+  \brief The TfException class is a base class for all TreeFrog exception classes.
+*/
+
+/*!
+  \fn TfException::TfException(const TfException &e)
+  \brief Copy constructor.
+*/
+
+/*!
+  \fn TfException::TfException(const QString &message, const char *fileName, int lineNumber)
+  \brief Constructor.
+*/
+
+/*!
+  \fn virtual TfException::~TfException() throw()
+  \brief Destructor.
+*/
+
+/*!
+  \fn QString TfException::message() const
+  \brief Returns the message.
+*/
+
+/*!
+  \fn QString TfException::fileName() const
+  \brief Returns the file name.
+*/
+
+/*!
+  \fn int TfException::lineNumber() const
+  \brief Return the line number.
+*/
+
+/*!
+  \fn virtual void TfException::raise() const
+  \brief Raises the exception.
+*/
+
+/*!
+  \fn virtual Exception *TfException::clone() const
+  \brief Creates and returns a deep copy of the current data.
+*/
+
+/*!
+  \fn virtual QString TfException::className() const
+  \brief Returns exception class name.
+*/
+
+
+
+/*!
   \class RuntimeException
   \brief The RuntimeException class represents an exception that
   can be thrown when runtime error occurs.
@@ -22,28 +74,18 @@
 */
 
 /*!
-  \fn QString RuntimeException::message() const
-  \brief Returns the message.
-*/
-
-/*!
-  \fn QString RuntimeException::fileName() const
-  \brief Returns the file name.
-*/
-
-/*!
-  \fn int RuntimeException::lineNumber() const
-  \brief Return the line number.
-*/
-
-/*!
-  \fn virtual void RuntimeException::raise() const
+  \fn void RuntimeException::raise() const override
   \brief Raises the exception.
 */
 
 /*!
-  \fn virtual Exception *RuntimeException::clone() const
+  \fn Exception *RuntimeException::clone() const override
   \brief Creates and returns a deep copy of the current data.
+*/
+
+/*!
+  \fn QString RuntimeException::className() const override
+  \brief Returns exception class name.
 */
 
 
@@ -70,28 +112,18 @@
 */
 
 /*!
-  \fn QString SecurityException::message() const
-  \brief Returns the message.
-*/
-
-/*!
-  \fn QString SecurityException::fileName() const
-  \brief Returns the file name.
-*/
-
-/*!
-  \fn int SecurityException::lineNumber() const
-  \brief Return the line number.
-*/
-
-/*!
-  \fn virtual void SecurityException::raise() const
+  \fn void SecurityException::raise() const override
   \brief Raises the exception.
 */
 
 /*!
-  \fn virtual Exception *SecurityException::clone() const
+  \fn Exception *SecurityException::clone() const override
   \brief Creates and returns a deep copy of the current data.
+*/
+
+/*!
+  \fn QString SecurityException::className() const override
+  \brief Returns exception class name.
 */
 
 
@@ -118,28 +150,18 @@
 */
 
 /*!
-  \fn QString SqlException::message() const
-  \brief Returns the message.
-*/
-
-/*!
-  \fn QString SqlException::fileName() const
-  \brief Returns the file name.
-*/
-
-/*!
-  \fn int SqlException::lineNumber() const
-  \brief Return the line number.
-*/
-
-/*!
-  \fn virtual void SqlException::raise() const
+  \fn void SqlException::raise() const override
   \brief Raises the exception.
 */
 
 /*!
-  \fn virtual Exception *SqlException::clone() const
+  \fn Exception *SqlException::clone() const override
   \brief Creates and returns a deep copy of the current data.
+*/
+
+/*!
+  \fn QString SqlException::className() const override
+  \brief Returns exception class name.
 */
 
 
@@ -157,7 +179,7 @@
 */
 
 /*!
-  \fn ClientErrorException::ClientErrorException(int statusCode)
+  \fn ClientErrorException::ClientErrorException(int statusCode, const char *fileName, int lineNumber)
   \brief Constructor.
 */
 
@@ -172,14 +194,20 @@
 */
 
 /*!
-  \fn virtual void ClientErrorException::raise() const
+  \fn void ClientErrorException::raise() const override
   \brief Raises the exception.
 */
 
 /*!
-  \fn virtual Exception *ClientErrorException::clone() const
+  \fn Exception *ClientErrorException::clone() const override
   \brief Creates and returns a deep copy of the current data.
 */
+
+/*!
+  \fn QString ClientErrorException::className() const override
+  \brief Returns exception class name.
+*/
+
 
 
 /*!
@@ -204,29 +232,20 @@
 */
 
 /*!
-  \fn QString KvsException::message() const
-  \brief Returns the message.
-*/
-
-/*!
-  \fn QString KvsException::fileName() const
-  \brief Returns the file name.
-*/
-
-/*!
-  \fn int KvsException::lineNumber() const
-  \brief Return the line number.
-*/
-
-/*!
-  \fn virtual void KvsException::raise() const
+  \fn void KvsException::raise() const override
   \brief Raises the exception.
 */
 
 /*!
-  \fn virtual Exception *KvsException::clone() const
+  \fn Exception *KvsException::clone() const override
   \brief Creates and returns a deep copy of the current data.
 */
+
+/*!
+  \fn QString KvsException::className() const override
+  \brief Returns exception class name.
+*/
+
 
 
 /*!
@@ -252,26 +271,16 @@
 */
 
 /*!
-  \fn QString StandardException::message() const
-  \brief Returns the message.
-*/
-
-/*!
-  \fn QString StandardException::fileName() const
-  \brief Returns the file name.
-*/
-
-/*!
-  \fn int StandardException::lineNumber() const
-  \brief Return the line number.
-*/
-
-/*!
-  \fn virtual void StandardException::raise() const
+  \fn void StandardException::raise() const override
   \brief Raises the exception.
 */
 
 /*!
-  \fn virtual Exception *StandardException::clone() const
+  \fn Exception *StandardException::clone() const override
   \brief Creates and returns a deep copy of the current data.
+*/
+
+/*!
+  \fn QString StandardException::className() const override
+  \brief Returns exception class name.
 */

--- a/src/tfexception.h
+++ b/src/tfexception.h
@@ -6,125 +6,103 @@
 #include <TGlobal>
 
 
-class T_CORE_EXPORT RuntimeException : public std::exception
+class T_CORE_EXPORT TfException : public std::exception
 {
 public:
-    RuntimeException(const RuntimeException &e)
+    TfException(const QString &message, const char *fileName = "", int lineNumber = 0)
+        : msg(message), file(fileName), line(lineNumber) { }
+    TfException(const TfException &e)
         : std::exception(e), msg(e.msg), file(e.file), line(e.line) { }
+    virtual ~TfException() throw() { }
+    QString message() const { return msg; }
+    QString fileName() const { return file; }
+    int lineNumber() const { return line; }
+
+    virtual void raise() const { throw *this; }
+    virtual std::exception *clone() const { return new TfException(*this); }
+    virtual QString className() const { return QLatin1String("TfException"); }
+
+private:
+    QString msg;
+    QString file;
+    int line;
+};
+
+
+class T_CORE_EXPORT RuntimeException : public TfException
+{
+public:
     RuntimeException(const QString &message, const char *fileName = "", int lineNumber = 0)
-        : msg(message), file(fileName), line(lineNumber) { }
-    virtual ~RuntimeException() throw() { }
-    QString message() const { return msg; }
-    QString fileName() const { return file; }
-    int lineNumber() const { return line; }
-    virtual void raise() const { throw *this; }
-    virtual std::exception *clone() const { return new RuntimeException(*this); }
+        : TfException(message, fileName, lineNumber) { }
 
-private:
-    QString msg;
-    QString file;
-    int line;
+    void raise() const override { throw *this; }
+    std::exception *clone() const override { return new RuntimeException(*this); }
+    QString className() const override { return QLatin1String("RuntimeException"); }
 };
 
 
-class T_CORE_EXPORT SecurityException : public std::exception
+class T_CORE_EXPORT SecurityException : public TfException
 {
 public:
-    SecurityException(const SecurityException &e)
-        : std::exception(e), msg(e.msg), file(e.file), line(e.line) { }
     SecurityException(const QString &message, const char *fileName = "", int lineNumber = 0)
-        : msg(message), file(fileName), line(lineNumber) { }
-    virtual ~SecurityException() throw() { }
-    QString message() const { return msg; }
-    QString fileName() const { return file; }
-    int lineNumber() const { return line; }
-    virtual void raise() const { throw *this; }
-    virtual std::exception *clone() const { return new SecurityException(*this); }
+        : TfException(message, fileName, lineNumber) { }
 
-private:
-    QString msg;
-    QString file;
-    int line;
+    void raise() const override { throw *this; }
+    std::exception *clone() const override { return new SecurityException(*this); }
+    QString className() const override { return QLatin1String("SecurityException"); }
 };
 
 
-class T_CORE_EXPORT SqlException : public std::exception
+class T_CORE_EXPORT SqlException : public TfException
 {
 public:
-    SqlException(const SqlException &e)
-        : std::exception(e), msg(e.msg), file(e.file), line(e.line) { }
     SqlException(const QString &message, const char *fileName = "", int lineNumber = 0)
-        : msg(message), file(fileName), line(lineNumber) { }
-    virtual ~SqlException() throw() { }
-    QString message() const { return msg; }
-    QString fileName() const { return file; }
-    int lineNumber() const { return line; }
-    virtual void raise() const { throw *this; }
-    virtual std::exception *clone() const { return new SqlException(*this); }
+        : TfException(message, fileName, lineNumber) { }
 
-private:
-    QString msg;
-    QString file;
-    int line;
+    void raise() const override { throw *this; }
+    std::exception *clone() const override { return new SqlException(*this); }
+    QString className() const override { return QLatin1String("SqlException"); }
 };
 
 
-class T_CORE_EXPORT KvsException : public std::exception
+class T_CORE_EXPORT KvsException : public TfException
 {
 public:
-    KvsException(const KvsException &e)
-        : std::exception(e), msg(e.msg), file(e.file), line(e.line) { }
     KvsException(const QString &message, const char *fileName = "", int lineNumber = 0)
-        : msg(message), file(fileName), line(lineNumber) { }
-    virtual ~KvsException() throw() { }
-    QString message() const { return msg; }
-    QString fileName() const { return file; }
-    int lineNumber() const { return line; }
-    virtual void raise() const { throw *this; }
-    virtual std::exception *clone() const { return new KvsException(*this); }
+        : TfException(message, fileName, lineNumber) { }
 
-private:
-    QString msg;
-    QString file;
-    int line;
+    void raise() const override { throw *this; }
+    std::exception *clone() const override { return new KvsException(*this); }
+    QString className() const override { return QLatin1String("KvsException"); }
 };
 
 
-class T_CORE_EXPORT ClientErrorException : public std::exception
+class T_CORE_EXPORT ClientErrorException : public TfException
 {
 public:
-    ClientErrorException(const ClientErrorException &e)
-        : std::exception(e), code(e.code) { }
-    ClientErrorException(int statusCode)
-        : code(statusCode) { }
-    virtual ~ClientErrorException() throw() { }
+    ClientErrorException(int statusCode, const char *fileName = "", int lineNumber = 0)
+        : TfException(QString("HTTP status code: %1").arg(statusCode), fileName, lineNumber),
+          code(statusCode) { }
+
     int statusCode() const { return code; }
-    virtual void raise() const { throw *this; }
-    virtual std::exception *clone() const { return new ClientErrorException(*this); }
+    void raise() const override { throw *this; }
+    std::exception *clone() const override { return new ClientErrorException(*this); }
+    QString className() const override { return QLatin1String("ClientErrorException"); }
 
 private:
     int code;
 };
 
 
-class T_CORE_EXPORT StandardException : public std::exception
+class T_CORE_EXPORT StandardException : public TfException
 {
 public:
-    StandardException(const StandardException &e)
-        : std::exception(e), msg(e.msg), file(e.file), line(e.line) { }
     StandardException(const QString &message, const char *fileName = "", int lineNumber = 0)
-        : msg(message), file(fileName), line(lineNumber) { }
-    virtual ~StandardException() throw() { }
-    QString message() const { return msg; }
-    QString fileName() const { return file; }
-    int lineNumber() const { return line; }
-    virtual void raise() const { throw *this; }
-    virtual std::exception *clone() const { return new StandardException(*this); }
+        : TfException(message, fileName, lineNumber) { }
 
-private:
-    QString msg;
-    QString file;
-    int line;
+    void raise() const override { throw *this; }
+    std::exception *clone() const override { return new StandardException(*this); }
+    QString className() const override { return QLatin1String("StandardException"); }
 };
 
 #endif // TFEXCEPTION_H

--- a/src/tfexception.h
+++ b/src/tfexception.h
@@ -4,15 +4,15 @@
 #include <exception>
 #include <QString>
 #include <TGlobal>
-
+#include <QByteArray>
 
 class T_CORE_EXPORT TfException : public std::exception
 {
 public:
     TfException(const QString &message, const char *fileName = "", int lineNumber = 0)
-        : msg(message), file(fileName), line(lineNumber) { }
+        : msg(message), file(fileName), line(lineNumber), msgLocal8Bit(message.toLocal8Bit()) { }
     TfException(const TfException &e)
-        : std::exception(e), msg(e.msg), file(e.file), line(e.line) { }
+        : std::exception(e), msg(e.msg), file(e.file), line(e.line), msgLocal8Bit(e.msgLocal8Bit) { }
     virtual ~TfException() throw() { }
     QString message() const { return msg; }
     QString fileName() const { return file; }
@@ -22,10 +22,13 @@ public:
     virtual std::exception *clone() const { return new TfException(*this); }
     virtual QString className() const { return QLatin1String("TfException"); }
 
+    const char *what() const override { return msgLocal8Bit.constData(); }
+
 private:
     QString msg;
     QString file;
     int line;
+    QByteArray msgLocal8Bit;
 };
 
 


### PR DESCRIPTION
Fix for ticket #208.

Also added TfException class as a base class for all TreeFrog exceptions.

Now the exception handling in TActionContext::execute() can be simplified to something like this:

```
try {
..
} catch (ClientErrorException &e) {
    tWarn("Caught %s: status code:%d", qPrintable(e.className()), e.statusCode());
    tSystemWarn("Caught %s: status code:%d", qPrintable(e.className()), e.statusCode());
    int bytes = writeResponse(e.statusCode(), responseHeader);
    accessLogger.setResponseBytes( bytes );
    accessLogger.setStatusCode( e.statusCode() );
} catch (TfException &e) {
    tError("Caught %s: %s  [%s:%d]", qPrintable(e.className()), qPrintable(e.message()), qPrintable(e.fileName()), e.lineNumber());
    tSystemError("Caught %s: %s  [%s:%d]", qPrintable(e.className()), qPrintable(e.message()), qPrintable(e.fileName()), e.lineNumber());
    closeHttpSocket();
} catch (...) {
    tError("Caught Exception");
    tSystemError("Caught Exception");
    closeHttpSocket();
}
```