### PR TITLE
Fix debug symbol loading for libcontroller.so and libview.so

### DIFF
--- a/src/tapplicationserverbase.cpp
+++ b/src/tapplicationserverbase.cpp
@@ -8,6 +8,8 @@
 #include <QLibrary>
 #include <QList>
 #include <QDir>
+#include <QString>
+#include <QStringBuilder>
 #include <QDateTime>
 #include <TWebApplication>
 #include <TActionContext>
@@ -57,7 +59,7 @@ bool TApplicationServerBase::loadLibraries()
 #endif
 
         for (auto &libname : libs) {
-            auto lib = new QLibrary(libname);
+            auto lib = new QLibrary(libPath % "/" % libname);
             if (lib->load()) {
                 tSystemDebug("Library loaded: %s", qPrintable(lib->fileName()));
                 libsLoaded << lib;


### PR DESCRIPTION
Previously, in order to load the debug symbols for libcontroller.so
and libview.so, the solib-search-path gdb variable had to be set.
Loading the lib using an absolute path will always work out of the box.