### PR TITLE
Change for issue #264, replace QDir::separator() by "/".

### DIFF
--- a/examples/devapp/controllers/hellocontroller.cpp
+++ b/examples/devapp/controllers/hellocontroller.cpp
@@ -177,7 +177,7 @@ void HelloController::upload()
 {
     T_TRACEFUNC();
     
-    httpRequest().multipartFormData().renameUploadedFile("FiletoUpload", Tf::app()->webRootPath() + "tmp" + QDir::separator() + "hogehoge.tmp", true);
+    httpRequest().multipartFormData().renameUploadedFile("FiletoUpload", Tf::app()->webRootPath() + "tmp/hogehoge.tmp", true);
 }
 
 

--- a/src/tactionview.cpp
+++ b/src/tactionview.cpp
@@ -58,7 +58,7 @@ QString TActionView::renderPartial(const QString &templateName, const QVariantMa
 */
 QString TActionView::renderReact(const QString &component)
 {
-    QStringList path = { (Tf::app()->publicPath() + "js" + QDir::separator() + "components"),
+    QStringList path = { (Tf::app()->publicPath() + "js/components"),
                          (Tf::app()->publicPath() + "js")
     };
     return TReactComponent(component, path).renderToString(component);

--- a/src/tsessionfilestore.cpp
+++ b/src/tsessionfilestore.cpp
@@ -130,6 +130,6 @@ int TSessionFileStore::gc(const QDateTime &expire)
 
 QString TSessionFileStore::sessionDirPath()
 {
-    static const QString path = Tf::app()->tmpPath() + QLatin1String(SESSION_DIR_NAME) + QDir::separator();
+    static const QString path = Tf::app()->tmpPath() + QLatin1String(SESSION_DIR_NAME) + "/";
     return path;
 }

--- a/src/tsqlquery.cpp
+++ b/src/tsqlquery.cpp
@@ -73,8 +73,7 @@ bool TSqlQuery::load(const QString &filename)
 */
 QString TSqlQuery::queryDirPath() const
 {
-    QString dir = Tf::app()->webRootPath() + Tf::appSettings()->value(Tf::SqlQueriesStoredDirectory).toString();
-    dir.replace(QChar('/'), QDir::separator());
+    const QString dir = Tf::app()->webRootPath() + Tf::appSettings()->value(Tf::SqlQueriesStoredDirectory).toString();
     return dir;
 }
 

--- a/src/ttemporaryfile.cpp
+++ b/src/ttemporaryfile.cpp
@@ -29,7 +29,7 @@ TTemporaryFile::TTemporaryFile()
     if (Tf::app()) {
         tmppath = Tf::appSettings()->value(Tf::UploadTemporaryDirectory).toString().trimmed();
         if (!tmppath.isEmpty() && QDir::isRelativePath(tmppath)) {
-            tmppath = Tf::app()->webRootPath() + tmppath + QDir::separator();
+            tmppath = Tf::app()->webRootPath() + tmppath + "/";
         }
 
         if (!QDir(tmppath).exists()) {
@@ -41,8 +41,8 @@ TTemporaryFile::TTemporaryFile()
         tmppath = QDir::tempPath();
     }
 
-    if (!tmppath.endsWith(QDir::separator())) {
-        tmppath += QDir::separator();
+    if (!tmppath.endsWith("/")) {
+        tmppath += "/";
     }
     setFileTemplate(tmppath + QLatin1String("tf_temp.XXXXXXXXXXXXXXXX"));
 }

--- a/src/twebapplication.cpp
+++ b/src/twebapplication.cpp
@@ -66,8 +66,8 @@ TWebApplication::TWebApplication(int &argc, char **argv)
         } else {
             if (QDir(arg).exists()) {
                 _webRootAbsolutePath = arg;
-                if (!_webRootAbsolutePath.endsWith(QDir::separator())) {
-                    _webRootAbsolutePath += QDir::separator();
+                if (!_webRootAbsolutePath.endsWith("/")) {
+                    _webRootAbsolutePath += "/";
                 }
             }
         }
@@ -75,7 +75,7 @@ TWebApplication::TWebApplication(int &argc, char **argv)
 
     QDir webRoot(_webRootAbsolutePath);
     if (webRoot.exists()) {
-        _webRootAbsolutePath = webRoot.absolutePath() + QDir::separator();
+        _webRootAbsolutePath = webRoot.absolutePath() + "/";
     }
 
     // Sets application name
@@ -93,7 +93,7 @@ TWebApplication::TWebApplication(int &argc, char **argv)
     if (QFileInfo(configPath() + "internet_media_types.ini").exists()) {
         mediaTypes = new QSettings(configPath() + "internet_media_types.ini", QSettings::IniFormat, this);
     } else {
-        mediaTypes = new QSettings(configPath() + "initializers" + QDir::separator() + "internet_media_types.ini", QSettings::IniFormat, this);
+        mediaTypes = new QSettings(configPath() + "initializers/internet_media_types.ini", QSettings::IniFormat, this);
     }
     // Gets codecs
     _codecInternal = searchCodec(Tf::appSettings()->value(Tf::InternalEncoding).toByteArray().trimmed().data());
@@ -181,7 +181,7 @@ bool TWebApplication::webRootExists() const
 */
 QString TWebApplication::publicPath() const
 {
-    return webRootPath() + "public" + QDir::separator();
+    return webRootPath() + "public/";
 }
 
 /*!
@@ -189,7 +189,7 @@ QString TWebApplication::publicPath() const
 */
 QString TWebApplication::configPath() const
 {
-    return webRootPath() + "config" + QDir::separator();
+    return webRootPath() + "config/";
 }
 
 /*!
@@ -197,7 +197,7 @@ QString TWebApplication::configPath() const
 */
 QString TWebApplication::libPath() const
 {
-    return webRootPath()+ "lib" + QDir::separator();
+    return webRootPath()+ "lib/";
 }
 
 /*!
@@ -205,7 +205,7 @@ QString TWebApplication::libPath() const
 */
 QString TWebApplication::logPath() const
 {
-    return webRootPath() + "log" + QDir::separator();
+    return webRootPath() + "log/";
 }
 
 /*!
@@ -213,7 +213,7 @@ QString TWebApplication::logPath() const
 */
 QString TWebApplication::pluginPath() const
 {
-    return webRootPath() + "plugin" + QDir::separator();
+    return webRootPath() + "plugin/";
 }
 
 /*!
@@ -221,7 +221,7 @@ QString TWebApplication::pluginPath() const
 */
 QString TWebApplication::tmpPath() const
 {
-    return webRootPath() + "tmp" + QDir::separator();
+    return webRootPath() + "tmp/";
 }
 
 /*!

--- a/tools/tfmanager/main.cpp
+++ b/tools/tfmanager/main.cpp
@@ -212,7 +212,7 @@ static void writeStartupLog()
 static QString pidFilePath(const QString &appRoot = QString())
 {
     return (appRoot.isEmpty()) ? Tf::app()->tmpPath() + PID_FILENAME
-        : appRoot + QDir::separator() + "tmp" + QDir::separator() +  PID_FILENAME;
+        : appRoot + "/tmp/" +  PID_FILENAME;
 }
 
 
@@ -249,7 +249,7 @@ static QString runningApplicationsFilePath()
         home = QLatin1String("/root");
     }
 #endif
-    return home + QDir::separator() + ".treefrog" + QDir::separator() + "runnings";
+    return home + "/.treefrog/runnings";
 }
 
 
@@ -324,7 +324,7 @@ static void cleanupRunningApplicationList()
 
 static QVariant applicationSettingValue(const QString &appRoot, const QString &key)
 {
-    QString appIni = appRoot + QDir::separator() + QLatin1String("config") + QDir::separator() + "application.ini";
+    QString appIni = appRoot + QLatin1String("/config/application.ini");
     return QSettings(appIni, QSettings::IniFormat).value(key);
 }
 

--- a/tools/tfmanager/systembusdaemon.cpp
+++ b/tools/tfmanager/systembusdaemon.cpp
@@ -21,7 +21,7 @@ static int maxServers = 0;
 #ifdef Q_OS_UNIX
 static QString unixDomainServerDir()
 {
-    return QDir::cleanPath(QDir::tempPath()) + QDir::separator();
+    return QDir::cleanPath(QDir::tempPath()) + "/";
 }
 #endif
 

--- a/tools/tmake/main.cpp
+++ b/tools/tmake/main.cpp
@@ -52,9 +52,9 @@ int main(int argc, char *argv[])
 
     if (!args.value("-f").isEmpty()) {
         appIni = args.value("-f");
-        devIni = QFileInfo(appIni).dir().path() + QDir::separator() + "development.ini";
+        devIni = QFileInfo(appIni).dir().path() + "/development.ini";
     } else {
-        QString dir = QLatin1String("..") + QDir::separator() + QLatin1String("..") + QDir::separator() + "config" +  QDir::separator();
+        const QString dir("../../config/");
         appIni = dir + "application.ini";
         devIni = dir + "development.ini";
     }

--- a/tools/tmake/viewconverter.cpp
+++ b/tools/tmake/viewconverter.cpp
@@ -197,5 +197,5 @@ QString ViewConverter::getViewClassName(const QFileInfo &fileInfo)
 QString ViewConverter::changeFileExtension(const QString &filePath, const QString &ext)
 {
     QFileInfo fileInfo(filePath);
-    return fileInfo.absolutePath() + QDir::separator() + fileInfo.completeBaseName() + QLatin1Char('.') + ext;
+    return fileInfo.absolutePath() + "/" + fileInfo.completeBaseName() + QLatin1Char('.') + ext;
 }

--- a/tools/tspawn/main.cpp
+++ b/tools/tspawn/main.cpp
@@ -27,11 +27,11 @@
 #include <ctime>
 
 #define L(str)  QLatin1String(str)
-#define SEP   QDir::separator()
-#define D_CTRLS   (QLatin1String("controllers") + SEP)
-#define D_MODELS  (QLatin1String("models") + SEP)
-#define D_VIEWS   (QLatin1String("views") + SEP)
-#define D_HELPERS (QLatin1String("helpers") + SEP)
+#define SEP   "/"
+#define D_CTRLS   (QLatin1String("controllers/") + SEP)
+#define D_MODELS  (QLatin1String("models/") + SEP)
+#define D_VIEWS   (QLatin1String("views/") + SEP)
+#define D_HELPERS (QLatin1String("helpers/") + SEP)
 
 enum SubCommand {
     Invalid = 0,

--- a/tools/tspawn/main.cpp
+++ b/tools/tspawn/main.cpp
@@ -27,11 +27,10 @@
 #include <ctime>
 
 #define L(str)  QLatin1String(str)
-#define SEP   "/"
-#define D_CTRLS   (QLatin1String("controllers/") + SEP)
-#define D_MODELS  (QLatin1String("models/") + SEP)
-#define D_VIEWS   (QLatin1String("views/") + SEP)
-#define D_HELPERS (QLatin1String("helpers/") + SEP)
+#define D_CTRLS   QLatin1String("controllers/")
+#define D_MODELS  QLatin1String("models/")
+#define D_VIEWS   QLatin1String("views/")
+#define D_HELPERS QLatin1String("helpers/")
 
 enum SubCommand {
     Invalid = 0,
@@ -109,19 +108,19 @@ public:
     {
         append(L("controllers"));
         append(L("models"));
-        append(L("models") + SEP + "sqlobjects");
-        append(L("models") + SEP + "mongoobjects");
+        append(L("models/sqlobjects"));
+        append(L("models/mongoobjects"));
         append(L("views"));
-        append(L("views") + SEP + "layouts");
-        append(L("views") + SEP + "mailer");
-        append(L("views") + SEP + "partial");
-        append(L("views") + SEP + "_src");
+        append(L("views/layouts"));
+        append(L("views/mailer"));
+        append(L("views/partial"));
+        append(L("views/_src"));
         append(L("helpers"));
         append(L("config"));
         append(L("public"));
-        append(L("public") + SEP + "images");
-        append(L("public") + SEP + "js");
-        append(L("public") + SEP + "css");
+        append(L("public/images"));
+        append(L("public/js"));
+        append(L("public/css"));
         append(L("db"));
         append(L("lib"));
         append(L("log"));
@@ -142,55 +141,55 @@ public:
     FilePaths() : QStringList()
     {
         append(L("appbase.pri"));
-        append(L("controllers") + SEP + "controllers.pro");
-        append(L("controllers") + SEP + "applicationcontroller.h");
-        append(L("controllers") + SEP + "applicationcontroller.cpp");
-        append(L("models") + SEP + "models.pro");
+        append(L("controllers/controllers.pro"));
+        append(L("controllers/applicationcontroller.h"));
+        append(L("controllers/applicationcontroller.cpp"));
+        append(L("models/models.pro"));
 #ifdef Q_OS_WIN
-        append(L("models") + SEP + "_dummymodel.h");
-        append(L("models") + SEP + "_dummymodel.cpp");
+        append(L("models/_dummymodel.h");
+        append(L("models/_dummymodel.cpp");
 #endif
-        append(L("views") + SEP + "views.pro");
-        append(L("views") + SEP + "_src" + SEP + "_src.pro");
-        append(L("views") + SEP + "layouts" + SEP + ".trim_mode");
-        append(L("views") + SEP + "mailer"  + SEP + ".trim_mode");
-        append(L("views") + SEP + "partial" + SEP + ".trim_mode");
-        append(L("helpers") + SEP + "helpers.pro");
-        append(L("helpers") + SEP + "applicationhelper.h");
-        append(L("helpers") + SEP + "applicationhelper.cpp");
-        append(L("config") + SEP + "application.ini");
-        append(L("config") + SEP + "database.ini");
-        append(L("config") + SEP + "development.ini");
-        append(L("config") + SEP + "internet_media_types.ini");
-        append(L("config") + SEP + "logger.ini");
-        append(L("config") + SEP + "mongodb.ini");
-        append(L("config") + SEP + "redis.ini");
-        append(L("config") + SEP + "routes.cfg");
-        append(L("config") + SEP + "validation.ini");
-        append(L("config") + SEP + "cache.ini");
-        append(L("public") + SEP + "403.html");
-        append(L("public") + SEP + "404.html");
-        append(L("public") + SEP + "413.html");
-        append(L("public") + SEP + "500.html");
-        append(L("script") + SEP + "JSXTransformer.js");
-        append(L("script") + SEP + "react.js");             // React
-        append(L("script") + SEP + "react-with-addons.js"); // React
-        append(L("script") + SEP + "react-dom-server.js");  // React
+        append(L("views/views.pro"));
+        append(L("views/_src/_src.pro"));
+        append(L("views/layouts/.trim_mode"));
+        append(L("views/mailer/.trim_mode"));
+        append(L("views/partial/.trim_mode"));
+        append(L("helpers/helpers.pro"));
+        append(L("helpers/applicationhelper.h"));
+        append(L("helpers/applicationhelper.cpp"));
+        append(L("config/application.ini"));
+        append(L("config/database.ini"));
+        append(L("config/development.ini"));
+        append(L("config/internet_media_types.ini"));
+        append(L("config/logger.ini"));
+        append(L("config/mongodb.ini"));
+        append(L("config/redis.ini"));
+        append(L("config/routes.cfg"));
+        append(L("config/validation.ini"));
+        append(L("config/cache.ini"));
+        append(L("public/403.html"));
+        append(L("public/404.html"));
+        append(L("public/413.html"));
+        append(L("public/500.html"));
+        append(L("script/JSXTransformer.js"));
+        append(L("script/react.js"));             // React
+        append(L("script/react-with-addons.js")); // React
+        append(L("script/react-dom-server.js"));  // React
         // CMake
         append(L("CMakeLists.txt"));
-        append(L("cmake") + SEP +"CacheClean.cmake");
-        append(L("cmake") + SEP +"TargetCmake.cmake");
-        append(L("controllers") + SEP + "CMakeLists.txt");
-        append(L("models") + SEP + "CMakeLists.txt");
-        append(L("views") + SEP + "CMakeLists.txt");
-        append(L("helpers") + SEP + "CMakeLists.txt");
+        append(L("cmake/CacheClean.cmake"));
+        append(L("cmake/TargetCmake.cmake"));
+        append(L("controllers/CMakeLists.txt"));
+        append(L("models/CMakeLists.txt"));
+        append(L("views/CMakeLists.txt"));
+        append(L("helpers/CMakeLists.txt"));
     }
 };
 Q_GLOBAL_STATIC(FilePaths, filePaths)
 
 
-const QString appIni = QLatin1String("config") + SEP + "application.ini";
-const QString devIni = QLatin1String("config") + SEP + "development.ini";
+const QString appIni = QLatin1String("config/application.ini");
+const QString devIni = QLatin1String("config/development.ini");
 static QSettings appSettings(appIni, QSettings::IniFormat);
 static QSettings devSettings(devIni, QSettings::IniFormat);
 static QString templateSystem;
@@ -230,7 +229,7 @@ static QStringList rmfiles(const QStringList &files, bool &allRemove, bool &quit
             break;
 
         const QString &fname = i.next();
-        QFile file(baseDir + SEP + fname);
+        QFile file(baseDir + "/" + fname);
         if (!file.exists())
             continue;
 
@@ -285,7 +284,7 @@ static QStringList rmfiles(const QStringList &files, bool &allRemove, bool &quit
 
     if (!proj.isEmpty()) {
         // Updates the project file
-        ProjectFileGenerator(baseDir + SEP + proj).remove(rmd);
+        ProjectFileGenerator(baseDir + "/" + proj).remove(rmd);
     }
 
     return rmd;
@@ -339,18 +338,18 @@ static bool createNewApplication(const QString &name)
 
     // Creates sub-directories
     for (const QString &str : *subDirs()) {
-        QString d = name + SEP + str;
+        QString d = name + "/" + str;
         if (!mkpath(dir, d)) {
             return false;
         }
     }
 
     // Copies files
-    copy(dataDirPath + "app.pro", name + SEP + name + ".pro");
+    copy(dataDirPath + "app.pro", name + "/" + name + ".pro");
 
     for (auto &path : *filePaths()) {
         QString filename = QFileInfo(path).fileName();
-        QString dst = name + SEP + path;
+        QString dst = name + "/" + path;
 
         if (filename == "CMakeLists.txt") {
             copy(dataDirPath + path, dst);
@@ -366,7 +365,7 @@ static bool createNewApplication(const QString &name)
 
 #ifdef Q_OS_WIN
     // Add dummy model files
-    ProjectFileGenerator progen(name + SEP + D_MODELS + "models.pro");
+    ProjectFileGenerator progen(name + "/" + D_MODELS + "models.pro");
     QStringList dummy = { "_dummymodel.h", "_dummymodel.cpp" };
     progen.add(dummy);
 #endif
@@ -400,26 +399,26 @@ static int deleteScaffold(const QString &name)
         ctrls << str + "controller.h"
               << str + "controller.cpp";
 
-        models << QLatin1String("sqlobjects") + SEP + str + "object.h"
-               << QLatin1String("mongoobjects") + SEP + str + "object.h"
+        models << QLatin1String("sqlobjects/") + str + "object.h"
+               << QLatin1String("mongoobjects/") + str + "object.h"
                << str + ".h"
                << str + ".cpp";
 
         // Template system
         if (templateSystem == "otama") {
-            views << str + SEP + "index.html"
-                  << str + SEP + "index.otm"
-                  << str + SEP + "show.html"
-                  << str + SEP + "show.otm"
-                  << str + SEP + "create.html"
-                  << str + SEP + "create.otm"
-                  << str + SEP + "save.html"
-                  << str + SEP + "save.otm";
+            views << str + "/index.html"
+                  << str + "/index.otm"
+                  << str + "/show.html"
+                  << str + "/show.otm"
+                  << str + "/create.html"
+                  << str + "/create.otm"
+                  << str + "/save.html"
+                  << str + "/save.otm";
         } else if (templateSystem == "erb") {
-            views << str + SEP + "index.erb"
-                  << str + SEP + "show.erb"
-                  << str + SEP + "create.erb"
-                  << str + SEP + "save.erb";
+            views << str + "/index.erb"
+                  << str + "/show.erb"
+                  << str + "/create.erb"
+                  << str + "/save.erb";
         } else {
             qCritical("Invalid template system specified: %s", qPrintable(templateSystem));
             return 2;
@@ -445,7 +444,7 @@ static int deleteScaffold(const QString &name)
         // Removes views
         QStringList rmd = rmfiles(views, allRemove, quit, D_VIEWS);
         if (!rmd.isEmpty()) {
-            QString path = D_VIEWS + "_src" + SEP + str;
+            QString path = D_VIEWS + "_src/" + str;
             QFile::remove(path + "_indexView.cpp");
             QFile::remove(path + "_showView.cpp");
             QFile::remove(path + "_entryView.cpp");
@@ -474,7 +473,7 @@ static bool checkIniFile()
 static void printSuccessMessage(const QString &model)
 {
     QString msg;
-    if (!QFile("Makefile").exists() && !QFile(L("build") + SEP + "Makefile").exists()) {
+    if (!QFile("Makefile").exists() && !QFile(L("build/Makefile")).exists()) {
         msg = "qmake:\n Run `qmake -r%0 CONFIG+=debug` to generate a Makefile for debug mode.\n Run `qmake -r%0 CONFIG+=release` to generate a Makefile for release mode.\n";
 #ifdef Q_OS_DARWIN
         msg = msg.arg(" -spec macx-clang");
@@ -529,7 +528,7 @@ int main(int argc, char *argv[])
         break;
 
     case ShowDriverPath: {
-        QString path = QLibraryInfo::location(QLibraryInfo::PluginsPath) + SEP + "sqldrivers";
+        QString path = QLibraryInfo::location(QLibraryInfo::PluginsPath) + "/sqldrivers";
         QFileInfo fi(path);
         if (!fi.exists() || !fi.isDir()) {
             qCritical("Error: database driver's directory not found");
@@ -557,7 +556,7 @@ int main(int argc, char *argv[])
         if (checkIniFile()) {
             // MongoDB settings
             QString mongoini = appSettings.value("MongoDbSettingsFile").toString().trimmed();
-            QString mnginipath = QLatin1String("config") + SEP + mongoini;
+            QString mnginipath = QLatin1String("config/") + mongoini;
 
             if (mongoini.isEmpty() || !QFile(mnginipath).exists()) {
                 qCritical("MongoDB settings file not found");
@@ -665,8 +664,8 @@ int main(int argc, char *argv[])
             break; }
 
         case WebSocketEndpoint: {
-            const QString appendpointfiles[] = { L("controllers") + SEP + "applicationendpoint.h",
-                                                 L("controllers") + SEP + "applicationendpoint.cpp" };
+            const QString appendpointfiles[] = { L("controllers/applicationendpoint.h"),
+                                                 L("controllers/applicationendpoint.cpp") };
 
             ProjectFileGenerator progen(D_CTRLS + "controllers.pro");
 
@@ -690,7 +689,7 @@ int main(int argc, char *argv[])
         case Mailer: {
             MailerGenerator mailgen(args.value(2), args.mid(3));
             mailgen.generate(D_CTRLS);
-            copy(dataDirPath + "mail.erb", D_VIEWS + "mailer" + SEP +"mail.erb");
+            copy(dataDirPath + "mail.erb", D_VIEWS + "mailer/mail.erb");
             break; }
 
         case Scaffold: {

--- a/tools/tspawn/main.cpp
+++ b/tools/tspawn/main.cpp
@@ -146,8 +146,8 @@ public:
         append(L("controllers/applicationcontroller.cpp"));
         append(L("models/models.pro"));
 #ifdef Q_OS_WIN
-        append(L("models/_dummymodel.h");
-        append(L("models/_dummymodel.cpp");
+        append(L("models/_dummymodel.h"));
+        append(L("models/_dummymodel.cpp"));
 #endif
         append(L("views/views.pro"));
         append(L("views/_src/_src.pro"));

--- a/tools/tspawn/tableschema.cpp
+++ b/tools/tspawn/tableschema.cpp
@@ -17,7 +17,7 @@ TableSchema::TableSchema(const QString &table, const QString &env)
     : tablename(table)
 {
     if (!dbSettings) {
-        QString path = QLatin1String("config") + QDir::separator() + "database.ini";
+        QString path = QLatin1String("config/database.ini");
         if (!QFile::exists(path)) {
             qCritical("not found, %s", qPrintable(path));
         }

--- a/tools/tspawn/util.cpp
+++ b/tools/tspawn/util.cpp
@@ -10,7 +10,7 @@
 #include <cstdio>
 #include "util.h"
 
-QString dataDirPath = QLatin1String(TREEFROG_DATA_DIR) + QDir::separator() + "defaults" + QDir::separator();
+QString dataDirPath = QLatin1String(TREEFROG_DATA_DIR) + "/defaults/";
 
 
 void copy(const QString &src, const QString &dst)


### PR DESCRIPTION
Treefrog uses QDir::separator() to build file paths.
https://doc.qt.io/qt-5.12/qdir.html#separator
You do not need to use this function to build file paths. If you always use "/", Qt will translate your paths to conform to the underlying operating system.