### PR TITLE
Use precompiled headers when building TreeFrog library

### DIFF
--- a/src/corelib.pro
+++ b/src/corelib.pro
@@ -71,6 +71,9 @@ isEmpty( use_gui ) {
   DEFINES += TF_USE_GUI_MODULE
 }
 
+CONFIG *= precompile_header
+PRECOMPILED_HEADER = precompile.h
+
 HEADERS += twebapplication.h
 SOURCES += twebapplication.cpp
 HEADERS += tapplicationserverbase.h

--- a/src/precompile.h
+++ b/src/precompile.h
@@ -1,0 +1,17 @@
+/* Add C includes here */
+
+#if defined __cplusplus
+/* Add C++ includes here */
+#include <QByteArray>
+#include <QDateTime>
+#include <QHash>
+#include <QList>
+#include <QMap>
+#include <QMetaType>
+#include <QObject>
+#include <QString>
+#include <QStringList>
+#include <QUrl>
+#include <QVariant>
+#include <QVector>
+#endif


### PR DESCRIPTION
More info:
https://doc.qt.io/qt-5/qmake-precompiledheaders.html