### PR TITLE
Do nothing in writeQueryLog() if query log is disabled.

### DIFF
--- a/src/tsystemglobal.cpp
+++ b/src/tsystemglobal.cpp
@@ -189,16 +189,18 @@ void Tf::traceQueryLog(const char *msg, ...)
 
 void Tf::writeQueryLog(const QString &query, bool success, const QSqlError &error)
 {
-    QString q = query;
+    if (sqllogstrm) {
+        QString q = query;
 
-    if (!success) {
-        QString err = (!error.databaseText().isEmpty()) ? error.databaseText() : error.text().trimmed();
-        if (!err.isEmpty()) {
-            err = QLatin1Char('[') + err + QLatin1String("] ");
+        if (!success) {
+            QString err = (!error.databaseText().isEmpty()) ? error.databaseText() : error.text().trimmed();
+            if (!err.isEmpty()) {
+                err = QLatin1Char('[') + err + QLatin1String("] ");
+            }
+            q = QLatin1String("(Query failed) ") + err + query;
         }
-        q = QLatin1String("(Query failed) ") + err + query;
+        Tf::traceQueryLog("%s", qPrintable(q));
     }
-    Tf::traceQueryLog("%s", qPrintable(q));
 }
 
 


### PR DESCRIPTION
This will speed up a bit TSqlQuery::exec() function when the query log is disabled.

![print_screen](https://user-images.githubusercontent.com/9396016/81820062-65604c00-9530-11ea-98d0-af6fd455aed9.png)
.

