### PR TITLE
Fix parsing X-Forwarded-For header.

### DIFF
--- a/defaults/application.ini
+++ b/defaults/application.ini
@@ -83,8 +83,18 @@ EnableHttpMethodOverride=false
 # the client, if true.
 EnableForwardedForHeader=false
 
-# Specify IP addresses of the proxy servers to work the feature of
-# X-Forwarded-For header.
+# If false is specified, only the right-most IP address in X-Forwarded-For
+# request header is parsed, otherwise all IP addresses in header are parsed
+# from right side to left stopping at the last non-trusted IP address.
+ParseForwardedForHeaderRecursively=false
+
+# Specify trusted proxy servers to work the feature of X-Forwarded-For header.
+# Set to a quoted semicolon-delimited list of IP addresses or subnets.
+# If the special value 'unix:' is specified, an UNIX-domain socket proxy will
+# be trusted.
+# Example 1: "unix:"
+# Example 2: "192.168.1.10; 192.168.1.20"
+# Example 3: "10.0.1.0/24; 10.0.2.0/255.255.255.0"
 TrustedProxyServers=
 
 # Sets the timeout in seconds during which a keep-alive HTTP connection

--- a/defaults/application.ini
+++ b/defaults/application.ini
@@ -89,12 +89,8 @@ EnableForwardedForHeader=false
 ParseForwardedForHeaderRecursively=false
 
 # Specify trusted proxy servers to work the feature of X-Forwarded-For header.
-# Set to a quoted semicolon-delimited list of IP addresses or subnets.
-# If the special value 'unix:' is specified, an UNIX-domain socket proxy will
-# be trusted.
-# Example 1: "unix:"
-# Example 2: "192.168.1.10; 192.168.1.20"
-# Example 3: "10.0.1.0/24; 10.0.2.0/255.255.255.0"
+# Set to a quoted comma-delimited list of IP addresses or subnets,
+# for example: "192.168.1.10, 10.0.1.0/24, 10.0.2.0/255.255.255.0"
 TrustedProxyServers=
 
 # Sets the timeout in seconds during which a keep-alive HTTP connection

--- a/src/tappsettings.cpp
+++ b/src/tappsettings.cpp
@@ -41,6 +41,7 @@ public:
         insert(Tf::EnableCsrfProtectionModule, "EnableCsrfProtectionModule");
         insert(Tf::EnableHttpMethodOverride, "EnableHttpMethodOverride");
         insert(Tf::EnableForwardedForHeader, "EnableForwardedForHeader");
+        insert(Tf::ParseForwardedForHeaderRecursively, "ParseForwardedForHeaderRecursively");
         insert(Tf::TrustedProxyServers, "TrustedProxyServers");
         insert(Tf::HttpKeepAliveTimeout, "HttpKeepAliveTimeout");
         insert(Tf::LDPreload, "LDPreload");

--- a/src/tfnamespace.h
+++ b/src/tfnamespace.h
@@ -203,6 +203,7 @@ enum AppAttribute {
     SessionCookieSameSite,
     //
     EnableForwardedForHeader,
+    ParseForwardedForHeaderRecursively,
     TrustedProxyServers,
 };
 


### PR DESCRIPTION
Fixes parsing of the header, and it is now possible to trust Unix domain socket proxy and proxy servers in a subnet.

In nginx configuration (reverse proxy) add this line:
```
proxy_set_header X-Forwarded-For  $proxy_add_x_forwarded_for;
```

In Treefrog configuration add these lines:
```
EnableForwardedForHeader=true
ParseForwardedForHeaderRecursively=false
TrustedProxyServers="unix:; 192.168.0.10; 192.168.0.20"   # the value must be in quotes
```

Fixes #285
