### PR TITLE
Fix linker error caused by precompile header

### DIFF
--- a/src/precompile.h
+++ b/src/precompile.h
@@ -12,6 +12,5 @@
 #include <QString>
 #include <QStringList>
 #include <QUrl>
-#include <QVariant>
 #include <QVector>
 #endif


### PR DESCRIPTION
This fixes MSVC2015 linker error when building blogapp example.

```
link /NOLOGO /DYNAMICBASE /NXCOMPAT /DEBUG /DLL /SUBSYSTEM:WINDOWS /MANIFEST:embed /OUT:..\..\lib\view.dll @C:\Users\ADMINI~1\AppData\Local\Temp\view.dll.15124.63.jom
   Creating library ..\..\lib\view.lib and object ..\..\lib\view.exp
blog_createView.obj : error LNK2019: unresolved external symbol "__declspec(dllimport) public: class QMap<class QString,class QVariant>::const_iterator __thiscall QMap<class QString,class QVariant>::find(class QString const &)const " (__imp_?find@?$QMap@VQString@@VQVariant@@@@QBE?AVconst_iterator@1@ABVQString@@@Z) referenced in function "public: static void __cdecl QtMetaTypePrivate::QAssociativeIterableImpl::findImpl<class QMap<class QString,class QVariant> >(void const *,void const *,void * *)" (??$findImpl@V?$QMap@VQString@@VQVariant@@@@@QAssociativeIterableImpl@QtMetaTypePrivate@@SAXPBX0PAPAX@Z)
blog_saveView.obj : error LNK2001: unresolved external symbol "__declspec(dllimport) public: class QMap<class QString,class QVariant>::const_iterator __thiscall QMap<class QString,class QVariant>::find(class QString const &)const " (__imp_?find@?$QMap@VQString@@VQVariant@@@@QBE?AVconst_iterator@1@ABVQString@@@Z)
..\..\lib\view.dll : fatal error LNK1120: 1 unresolved externals
```

I apologize for the problem.