### PR TITLE
TSmtpMailer: Added support for SSL connections, prevent STRIPTLS attacks

### DIFF
--- a/defaults/application.ini
+++ b/defaults/application.ini
@@ -235,6 +235,9 @@ ActionMailer.smtp.HostName=
 # Specify the connection's port number.
 ActionMailer.smtp.Port=
 
+# Enables SSL/TLS connection if true.
+ActionMailer.smtp.EnableSSL=false
+
 # Enables STARTTLS extension if true.
 ActionMailer.smtp.EnableSTARTTLS=false
 

--- a/docs/ch/user-guide/helper-reference/mailer.md
+++ b/docs/ch/user-guide/helper-reference/mailer.md
@@ -64,6 +64,10 @@ void InformationMailer::send()
 ActionMailer.smtp.HostName=smtp.example.com
 # 指定连接的端口
 ActionMailer.smtp.Port=25
+# 如果为true，则启用SSL/TLS连接.
+ActionMailer.smtp.EnableSSL=false
+# 如果为true，则启用STARTTLS扩展.
+ActionMailer.smtp.EnableSTARTTLS=false
 # 如果true, 打开SMTP授权, 如果false, 关闭SMTP授权.
 ActionMailer.smtp.Authentication=false
 # 指定SMTP授权的用户名
@@ -81,8 +85,6 @@ ActionMailer.smtp.Authentication=true
 ```
 
 因为授权的方法, CRAM-MD5, LOGIN,和PLAIN(使用这个级别)是一起安装的, 所以授权处理是自动进行的.
-
-在这个框架中, SMTPS邮件发送是不支持的.
 
 ## 延时发送邮件
 

--- a/docs/en/user-guide/helper-reference/mailer.md
+++ b/docs/en/user-guide/helper-reference/mailer.md
@@ -66,6 +66,12 @@ ActionMailer.smtp.HostName=smtp.example.com
 # Specify the connection's port number.
 ActionMailer.smtp.Port=25
 
+# Enables SSL/TLS connection if true.
+ActionMailer.smtp.EnableSSL=false
+
+# Enables STARTTLS extension if true.
+ActionMailer.smtp.EnableSTARTTLS=false
+
 # Enables SMTP authentication if true; disables SMTP
 # authentication if false.
 ActionMailer.smtp.Authentication=false
@@ -88,8 +94,6 @@ ActionMailer.smtp.Authentication=true
 ```
 
 As for the authentication method, CRAM-MD5, LOGIN and PLAIN (using this priority) are mounted in a way, so that the authentication process is performed automatically.
-
-In this framework, SMTPS email sending is not supported.
 
 ## Delay sending the mail
 

--- a/docs/ja/user-guide/helper-reference/mailer.md
+++ b/docs/ja/user-guide/helper-reference/mailer.md
@@ -67,6 +67,12 @@ ActionMailer.smtp.HostName=smtp.example.com
 # Specify the connection's port number.  （ポート番号）
 ActionMailer.smtp.Port=25
 
+# Enables SSL/TLS connection if true.
+ActionMailer.smtp.EnableSSL=false
+
+# Enables STARTTLS extension if true.
+ActionMailer.smtp.EnableSTARTTLS=false
+
 # Enables SMTP authentication if true; disables SMTP
 # authentication if false.
 ActionMailer.smtp.Authentication=false
@@ -84,8 +90,6 @@ ActionMailer.smtp.DelayedDelivery=false
 
 SMTP 認証を行う場合、ActionMailer.smtp.Authentication=**true** を指定します。<br>
 認証方式には CRAM-MD5, LOGIN, PLAIN が実装されており、この優先度で自動的に認証処理が行われます。
-
-本フレームワークでは、SMTPSによるメール送信はサポートしていません。
 
 ## メールの遅延送信
 

--- a/src/tactionmailer.cpp
+++ b/src/tactionmailer.cpp
@@ -78,6 +78,7 @@ bool TActionMailer::deliver(const QString &templateName)
         TSmtpMailer *mailer = new TSmtpMailer();
         mailer->setHostName(Tf::appSettings()->value(Tf::ActionMailerSmtpHostName).toByteArray());
         mailer->setPort(Tf::appSettings()->value(Tf::ActionMailerSmtpPort).toUInt());
+        mailer->setSslEnabled(Tf::appSettings()->value(Tf::ActionMailerSmtpEnableSSL).toBool());
         mailer->setStartTlsEnabled(Tf::appSettings()->value(Tf::ActionMailerSmtpEnableSTARTTLS).toBool());
         mailer->setAuthenticationEnabled(Tf::appSettings()->value(Tf::ActionMailerSmtpAuthentication).toBool());
         mailer->setUserName(Tf::appSettings()->value(Tf::ActionMailerSmtpUserName).toByteArray());

--- a/src/tappsettings.cpp
+++ b/src/tappsettings.cpp
@@ -71,6 +71,7 @@ public:
         insert(Tf::ActionMailerDelayedDelivery, "ActionMailer.DelayedDelivery");
         insert(Tf::ActionMailerSmtpHostName, "ActionMailer.smtp.HostName");
         insert(Tf::ActionMailerSmtpPort, "ActionMailer.smtp.Port");
+        insert(Tf::ActionMailerSmtpEnableSSL, "ActionMailer.smtp.EnableSSL");
         insert(Tf::ActionMailerSmtpEnableSTARTTLS, "ActionMailer.smtp.EnableSTARTTLS");
         insert(Tf::ActionMailerSmtpAuthentication, "ActionMailer.smtp.Authentication");
         insert(Tf::ActionMailerSmtpUserName, "ActionMailer.smtp.UserName");

--- a/src/tfnamespace.h
+++ b/src/tfnamespace.h
@@ -189,6 +189,7 @@ enum AppAttribute {
     RedisSettingsFile,
     LDPreload,
     JavaScriptPath,
+    ActionMailerSmtpEnableSSL,
     ActionMailerSmtpEnableSTARTTLS,
     ListenAddress,
     //

--- a/src/tsmtpmailer.h
+++ b/src/tsmtpmailer.h
@@ -30,6 +30,7 @@ public:
     quint16 port() const { return smtpPort; }
     void setPort(quint16 port);
     void setAuthenticationEnabled(bool enable);
+    void setSslEnabled(bool enable);
     void setStartTlsEnabled(bool enable);
     void setPopBeforeSmtpAuthEnabled(const QString &popServer, quint16 port, bool apop, bool enable);
     void setUserName(const QByteArray &username);
@@ -72,9 +73,10 @@ private:
     quint16 smtpPort {0};
     TMailMessage mailMessage;
     QStringList svrAuthMethods;
-    bool authEnable {false};
-    bool tlsEnable {false};
-    bool tlsAvailable {false};
+    bool authEnabled {false};
+    bool sslEnabled {false};
+    bool startTlsEnabled {false};
+    bool startTlsAvailable {false};
     QByteArray userName;
     QByteArray password;
     TPopMailer *pop {nullptr};
@@ -84,13 +86,19 @@ private:
 
 inline void TSmtpMailer::setAuthenticationEnabled(bool enable)
 {
-    authEnable = enable;
+    authEnabled = enable;
+}
+
+
+inline void TSmtpMailer::setSslEnabled(bool enable)
+{
+    sslEnabled = enable;
 }
 
 
 inline void TSmtpMailer::setStartTlsEnabled(bool enable)
 {
-    tlsEnable = enable;
+    startTlsEnabled = enable;
 }
 
 


### PR DESCRIPTION
This patch fixes #290 and allows to connect to the SMTP server using an SSL connection.

To connect using SSL/TLS:
```
ActionMailer.smtp.HostName=smtp.gmail.com
ActionMailer.smtp.Port=465  # SMTPS port
ActionMailer.smtp.EnableSSL=true
...
```
To connect using STARTLS:
```
ActionMailer.smtp.HostName=smtp.gmail.com
ActionMailer.smtp.Port=587  # SMTP port
ActionMailer.smtp.EnableSTARTTLS=true      
...
```
If you set EnableSTARTTLS=true in application.ini and the server does not support STARTTLS, an error is reported.

Tested with Mailu and GMail (with turned on access for less secure apps).

