### PR TITLE
Made tSystemDebug() and tSystemTrace() no-op in release build.

### DIFF
--- a/src/tsystemglobal.cpp
+++ b/src/tsystemglobal.cpp
@@ -119,7 +119,7 @@ void Tf::releaseQueryLogger()
 }
 
 
-void tSystemError(const char *msg, ...)
+void Tf::logSystemError(const char *msg, ...)
 {
     va_list ap;
     va_start(ap, msg);
@@ -128,7 +128,7 @@ void tSystemError(const char *msg, ...)
 }
 
 
-void tSystemWarn(const char *msg, ...)
+void Tf::logSystemWarn(const char *msg, ...)
 {
     va_list ap;
     va_start(ap, msg);
@@ -137,7 +137,7 @@ void tSystemWarn(const char *msg, ...)
 }
 
 
-void tSystemInfo(const char *msg, ...)
+void Tf::logSystemInfo(const char *msg, ...)
 {
     va_list ap;
     va_start(ap, msg);
@@ -145,9 +145,9 @@ void tSystemInfo(const char *msg, ...)
     va_end(ap);
 }
 
-#ifndef TF_NO_DEBUG
+#ifdef QT_DEBUG
 
-void tSystemDebug(const char *msg, ...)
+void Tf::logSystemDebug(const char *msg, ...)
 {
     va_list ap;
     va_start(ap, msg);
@@ -156,7 +156,7 @@ void tSystemDebug(const char *msg, ...)
 }
 
 
-void tSystemTrace(const char *msg, ...)
+void Tf::logSystemTrace(const char *msg, ...)
 {
     va_list ap;
     va_start(ap, msg);
@@ -166,13 +166,10 @@ void tSystemTrace(const char *msg, ...)
 
 #else
 
-void tSystemDebug(const char *, ...)
-{
-}
-void tSystemTrace(const char *, ...) { }
+void Tf::logSystemDebug(const char *, ...) {}
+void Tf::logSystemTrace(const char *, ...) {}
 
 #endif
-
 
 void Tf::traceQueryLog(const char *msg, ...)
 {

--- a/src/tsystemglobal.h
+++ b/src/tsystemglobal.h
@@ -9,6 +9,17 @@
 class TAccessLog;
 class QSqlError;
 
+#define tSystemError(...) Tf::logSystemError(__VA_ARGS__)
+#define tSystemWarn(...) Tf::logSystemWarn(__VA_ARGS__)
+#define tSystemInfo(...) Tf::logSystemInfo(__VA_ARGS__)
+#ifdef QT_DEBUG
+#define tSystemDebug(...) Tf::logSystemDebug(__VA_ARGS__)
+#define tSystemTrace(...) Tf::logSystemTrace(__VA_ARGS__)
+#else
+#define tSystemDebug(...) ((void)0)
+#define tSystemTrace(...) ((void)0)
+#endif
+
 namespace Tf {
 T_CORE_EXPORT void setupSystemLogger();  // internal use
 T_CORE_EXPORT void releaseSystemLogger();  // internal use
@@ -35,36 +46,36 @@ enum SystemOpCode {
 };
 
 T_CORE_EXPORT QMap<QString, QVariant> settingsToMap(QSettings &settings, const QString &env = QString());
+
+T_CORE_EXPORT void logSystemError(const char *, ...)  // system error message
+#if defined(Q_CC_GNU) && !defined(__INSURE__)
+    __attribute__((format(printf, 1, 2)))
+#endif
+    ;
+
+T_CORE_EXPORT void logSystemWarn(const char *, ...)  // system warn message
+#if defined(Q_CC_GNU) && !defined(__INSURE__)
+    __attribute__((format(printf, 1, 2)))
+#endif
+    ;
+
+T_CORE_EXPORT void logSystemInfo(const char *, ...)  // system info message
+#if defined(Q_CC_GNU) && !defined(__INSURE__)
+    __attribute__((format(printf, 1, 2)))
+#endif
+    ;
+
+T_CORE_EXPORT void logSystemDebug(const char *, ...)  // system debug message
+#if defined(Q_CC_GNU) && !defined(__INSURE__)
+    __attribute__((format(printf, 1, 2)))
+#endif
+    ;
+
+T_CORE_EXPORT void logSystemTrace(const char *, ...)  // system trace message
+#if defined(Q_CC_GNU) && !defined(__INSURE__)
+    __attribute__((format(printf, 1, 2)))
+#endif
+    ;
 }
-
-T_CORE_EXPORT void tSystemError(const char *, ...)  // system error message
-#if defined(Q_CC_GNU) && !defined(__INSURE__)
-    __attribute__((format(printf, 1, 2)))
-#endif
-    ;
-
-T_CORE_EXPORT void tSystemWarn(const char *, ...)  // system warn message
-#if defined(Q_CC_GNU) && !defined(__INSURE__)
-    __attribute__((format(printf, 1, 2)))
-#endif
-    ;
-
-T_CORE_EXPORT void tSystemInfo(const char *, ...)  // system info message
-#if defined(Q_CC_GNU) && !defined(__INSURE__)
-    __attribute__((format(printf, 1, 2)))
-#endif
-    ;
-
-T_CORE_EXPORT void tSystemDebug(const char *, ...)  // system debug message
-#if defined(Q_CC_GNU) && !defined(__INSURE__)
-    __attribute__((format(printf, 1, 2)))
-#endif
-    ;
-
-T_CORE_EXPORT void tSystemTrace(const char *, ...)  // system trace message
-#if defined(Q_CC_GNU) && !defined(__INSURE__)
-    __attribute__((format(printf, 1, 2)))
-#endif
-    ;
 
 #endif  // TSYSTEMGLOBAL_H


### PR DESCRIPTION
Changed system logging functions to macros. In release build the tSystemDebug() and tSystemTrace() are now expanded to (void)0. so there will be no memory allocation and conversion performed by  qPrintable() in calls such as:

`tSystemDebug("Gets cached database: %s", qPrintable(tdb.connectionName()));`
