### PR TITLE
Minor performance improvements for HTTP requests

### DIFF
--- a/src/tactionthread.cpp
+++ b/src/tactionthread.cpp
@@ -216,7 +216,9 @@ QList<THttpRequest> TActionThread::readRequest(THttpSocket *socket)
         }
 
         if (Q_UNLIKELY(socket->state() != QAbstractSocket::ConnectedState)) {
-            tSystemWarn("Invalid descriptor (state:%d) sd:%d", (int)socket->state(), (int)socket->socketDescriptor());
+            if (socket->error() != QAbstractSocket::RemoteHostClosedError) {
+                tSystemWarn("Socket error:%d. Descriptor:%d", socket->error(), (int)socket->socketDescriptor());
+            }
             break;
         }
 

--- a/src/tactionthread.cpp
+++ b/src/tactionthread.cpp
@@ -259,7 +259,7 @@ bool TActionThread::handshakeForWebSocket(const THttpRequestHeader &header)
     // Switch to WebSocket
     int sd = TApplicationServerBase::duplicateSocket(_httpSocket->socketDescriptor());
     TWebSocket *ws = new TWebSocket(sd, _httpSocket->peerAddress(), header);
-    connect(ws, SIGNAL(disconnected()), ws, SLOT(deleteLater()));
+    connect(ws, &TWebSocket::disconnected, ws, &TWebSocket::deleteLater);
     ws->moveToThread(Tf::app()->thread());
 
     // WebSocket opening

--- a/src/tactionthread.cpp
+++ b/src/tactionthread.cpp
@@ -104,7 +104,6 @@ void TActionThread::run()
     };
 
     Counter counter(threadCounter);
-    QList<THttpRequest> reqs;
     QEventLoop eventLoop;
     _httpSocket = new THttpSocket();
 
@@ -119,7 +118,7 @@ void TActionThread::run()
 
     try {
         for (;;) {
-            reqs = readRequest(_httpSocket);
+            QList<THttpRequest> reqs = readRequest(_httpSocket);
             tSystemDebug("HTTP request count: %d", reqs.count());
 
             if (Q_UNLIKELY(reqs.isEmpty())) {
@@ -127,10 +126,10 @@ void TActionThread::run()
             }
 
             // WebSocket?
-            QByteArray connectionHeader = reqs[0].header().rawHeader("Connection").toLower();
+            QByteArray connectionHeader = reqs[0].header().rawHeader(QByteArrayLiteral("Connection")).toLower();
             if (Q_UNLIKELY(connectionHeader.contains("upgrade"))) {
-                QByteArray upgradeHeader = reqs[0].header().rawHeader("Upgrade").toLower();
-                tSystemDebug("Upgrade: %s", upgradeHeader.data());
+                QByteArray upgradeHeader = reqs[0].header().rawHeader(QByteArrayLiteral("Upgrade")).toLower();
+                tSystemDebug("Upgrade: %s", upgradeHeader.constData());
                 if (upgradeHeader == "websocket") {
                     // Switch to WebSocket
                     if (!handshakeForWebSocket(reqs[0].header())) {
@@ -238,9 +237,9 @@ QList<THttpRequest> TActionThread::readRequest(THttpSocket *socket)
 qint64 TActionThread::writeResponse(THttpResponseHeader &header, QIODevice *body)
 {
     if (keepAliveTimeout > 0) {
-        header.setRawHeader("Connection", "Keep-Alive");
+        header.setRawHeader(QByteArrayLiteral("Connection"), QByteArrayLiteral("Keep-Alive"));
     }
-    return _httpSocket->write(static_cast<THttpHeader *>(&header), body);
+    return _httpSocket->write(&header, body);
 }
 
 

--- a/src/thttpheader.cpp
+++ b/src/thttpheader.cpp
@@ -110,7 +110,7 @@ THttpRequestHeader::THttpRequestHeader(const QByteArray &str)
         // Parses the string
         parse(str.mid(i + 1));
 
-        QByteArray line = str.left(i).trimmed();
+        const QByteArray line = str.left(i).trimmed();
         i = line.indexOf(' ');
         if (i > 0) {
             _reqMethod = line.left(i);
@@ -160,9 +160,10 @@ QByteArray THttpRequestHeader::cookie(const QString &name) const
  */
 QList<TCookie> THttpRequestHeader::cookies() const
 {
-    QList<TCookie> result;
-    const QByteArrayList cookieStrings = rawHeader("Cookie").split(';');
+    const QByteArrayList cookieStrings = rawHeader(QByteArrayLiteral("Cookie")).split(';');
 
+    QList<TCookie> result;
+    result.reserve(cookieStrings.size());
     for (auto &ck : cookieStrings) {
         QByteArray ba = ck.trimmed();
         if (!ba.isEmpty()) {
@@ -177,8 +178,9 @@ QList<TCookie> THttpRequestHeader::cookies() const
 */
 QByteArray THttpRequestHeader::toByteArray() const
 {
+    QByteArray hdr = THttpHeader::toByteArray();
     QByteArray ba;
-    ba.reserve(256);
+    ba.reserve(256 + hdr.size());
     ba += _reqMethod;
     ba += ' ';
     ba += _reqUri;
@@ -187,7 +189,7 @@ QByteArray THttpRequestHeader::toByteArray() const
     ba += '.';
     ba += QByteArray::number(minorVersion());
     ba += CRLF;
-    ba += THttpHeader::toByteArray();
+    ba += hdr;
     return ba;
 }
 
@@ -249,7 +251,7 @@ THttpResponseHeader::THttpResponseHeader(const QByteArray &str) :
         // Parses the string
         parse(str.mid(i + 1));
 
-        QByteArray line = str.left(i).trimmed();
+        const QByteArray line = str.left(i).trimmed();
         i = line.indexOf("HTTP/");
         if (i == 0 && line.length() >= 12) {
             THttpHeader::_majorVersion = line.mid(5, 1).toInt();
@@ -282,8 +284,9 @@ void THttpResponseHeader::setStatusLine(int code, const QByteArray &text, int ma
 */
 QByteArray THttpResponseHeader::toByteArray() const
 {
+    QByteArray hdr = THttpHeader::toByteArray();
     QByteArray ba;
-    ba.reserve(256);
+    ba.reserve(256 + hdr.size());
     ba += "HTTP/";
     ba += QByteArray::number(majorVersion());
     ba += '.';
@@ -293,7 +296,7 @@ QByteArray THttpResponseHeader::toByteArray() const
     ba += ' ';
     ba += _reasonPhrase;
     ba += CRLF;
-    ba += THttpHeader::toByteArray();
+    ba += hdr;
     return ba;
 }
 

--- a/src/thttpsocket.cpp
+++ b/src/thttpsocket.cpp
@@ -45,8 +45,10 @@ THttpSocket::THttpSocket(QObject *parent) :
     } while (!socketManager[sid].compareExchange(nullptr, this));  // store a socket
     tSystemDebug("THttpSocket  sid:%d", sid);
 
-    connect(this, SIGNAL(readyRead()), this, SLOT(readRequest()));
-    connect(this, SIGNAL(requestWrite(const QByteArray &)), this, SLOT(writeRawData(const QByteArray &)), Qt::QueuedConnection);
+    qint64 (THttpSocket::*writeRawDataOverload)(const QByteArray &data) = &THttpSocket::writeRawData;
+
+    connect(this, &THttpSocket::readyRead, this, &THttpSocket::readRequest);
+    connect(this, &THttpSocket::requestWrite, this, writeRawDataOverload, Qt::QueuedConnection);
 
     idleElapsed = std::time(nullptr);
     readBuffer.reserve(RESERVED_BUFFER_SIZE);

--- a/src/thttpsocket.cpp
+++ b/src/thttpsocket.cpp
@@ -93,7 +93,7 @@ qint64 THttpSocket::write(const THttpHeader *header, QIODevice *body)
 
     // Writes HTTP header
     QByteArray hdata = header->toByteArray();
-    qint64 total = writeRawData(hdata.data(), hdata.size());
+    qint64 total = writeRawData(hdata.constData(), hdata.size());
     if (total < 0) {
         return -1;
     }
@@ -101,7 +101,7 @@ qint64 THttpSocket::write(const THttpHeader *header, QIODevice *body)
     if (body) {
         QBuffer *buffer = qobject_cast<QBuffer *>(body);
         if (buffer) {
-            if (writeRawData(buffer->data().data(), buffer->size()) != buffer->size()) {
+            if (writeRawData(buffer->data().constData(), buffer->size()) != buffer->size()) {
                 return -1;
             }
             total += buffer->size();
@@ -109,7 +109,7 @@ qint64 THttpSocket::write(const THttpHeader *header, QIODevice *body)
             QByteArray buf(WRITE_BUFFER_LENGTH, 0);
             qint64 readLen = 0;
             while ((readLen = body->read(buf.data(), buf.size())) > 0) {
-                if (writeRawData(buf.data(), readLen) != readLen) {
+                if (writeRawData(buf.constData(), readLen) != readLen) {
                     return -1;
                 }
                 total += readLen;
@@ -161,7 +161,7 @@ qint64 THttpSocket::writeRawData(const char *data, qint64 size)
 
 qint64 THttpSocket::writeRawData(const QByteArray &data)
 {
-    return writeRawData(data.data(), data.size());
+    return writeRawData(data.constData(), data.size());
 }
 
 
@@ -184,11 +184,11 @@ void THttpSocket::readRequest()
         if (lengthToRead > 0) {
             // Writes to buffer
             if (fileBuffer.isOpen()) {
-                if (fileBuffer.write(buf.data(), bytes) < 0) {
+                if (fileBuffer.write(buf.constData(), bytes) < 0) {
                     throw RuntimeException(QLatin1String("write error: ") + fileBuffer.fileName(), __FILE__, __LINE__);
                 }
             } else {
-                readBuffer.append(buf.data(), bytes);
+                readBuffer.append(buf.constData(), bytes);
             }
             lengthToRead = qMax(lengthToRead - bytes, 0LL);
 
@@ -213,7 +213,7 @@ void THttpSocket::readRequest()
                     }
                     if (readBuffer.length() > idx + 4) {
                         tSystemDebug("fileBuffer name: %s", qPrintable(fileBuffer.fileName()));
-                        if (fileBuffer.write(readBuffer.data() + idx + 4, readBuffer.length() - (idx + 4)) < 0) {
+                        if (fileBuffer.write(readBuffer.constData() + idx + 4, readBuffer.length() - (idx + 4)) < 0) {
                             throw RuntimeException(QLatin1String("write error: ") + fileBuffer.fileName(), __FILE__, __LINE__);
                         }
                     }

--- a/src/thttputility.cpp
+++ b/src/thttputility.cpp
@@ -100,7 +100,7 @@ QString THttpUtility::fromUrlEncoding(const QByteArray &enc)
 */
 QByteArray THttpUtility::toUrlEncoding(const QString &input, const QByteArray &exclude)
 {
-    return input.toUtf8().toPercentEncoding(exclude, "~").replace("%20", "+");
+    return input.toUtf8().toPercentEncoding(exclude, QByteArrayLiteral("~")).replace("%20", "+");
 }
 
 
@@ -361,7 +361,7 @@ QByteArray THttpUtility::timeZone()
     QByteArray tz;
     tz += (offset > 0) ? '+' : '-';
     offset = qAbs(offset);
-    tz += QString("%1%2").arg(offset / 60, 2, 10, QLatin1Char('0')).arg(offset % 60, 2, 10, QLatin1Char('0')).toLatin1();
+    tz += QStringLiteral("%1%2").arg(offset / 60, 2, 10, QLatin1Char('0')).arg(offset % 60, 2, 10, QLatin1Char('0')).toLatin1();
     tSystemDebug("tz: %s", tz.data());
     return tz;
 }

--- a/src/thttputility.cpp
+++ b/src/thttputility.cpp
@@ -430,30 +430,63 @@ QDateTime THttpUtility::fromHttpDateTimeUTCString(const QByteArray &utc)
 
 QByteArray THttpUtility::getUTCTimeString()
 {
-    static const char *DAY[] = {"Sun, ", "Mon, ", "Tue, ", "Wed, ", "Thu, ", "Fri, ", "Sat, "};
-    static const char *MONTH[] = {"Jan ", "Feb ", "Mar ", "Apr ", "May ", "Jun ", "Jul ", "Aug ", "Sep ", "Oct ", "Nov ", "Dec "};
+    static const QByteArray MONTH[] = {
+        "Jan ", "Feb ", "Mar ", "Apr ", "May ", "Jun ", "Jul ", "Aug ", "Sep ", "Oct ", "Nov ", "Dec "
+    };
+    static const QByteArray DAY_OF_WEEK[] = {
+        "Sun, ", "Mon, ", "Tue, ", "Wed, ", "Thu, ", "Fri, ", "Sat, "
+    };
+    static const QByteArray DAY_OF_MONTH[] = {
+        "01", "02", "03", "04", "05", "06", "07", "08", "09", "10",
+        "11", "12", "13", "14", "15", "16", "17", "18", "19", "20",
+        "21", "22", "23", "24", "25", "26", "27", "28", "29", "30",
+        "31"
+    };
+    static const QByteArray HOUR[] = {
+        "00", "01", "02", "03", "04", "05", "06", "07", "08", "09",
+        "10", "11", "12", "13", "14", "15", "16", "17", "18", "19",
+        "20", "21", "22", "23", "24"
+    };
+    static const QByteArray MINUTE[] = {
+        "00", "01", "02", "03", "04", "05", "06", "07", "08", "09",
+        "10", "11", "12", "13", "14", "15", "16", "17", "18", "19",
+        "20", "21", "22", "23", "24", "25", "26", "27", "28", "29",
+        "30", "31", "32", "33", "34", "35", "36", "37", "38", "39",
+        "40", "41", "42", "43", "44", "45", "46", "47", "48", "49",
+        "50", "51", "52", "53", "54", "55", "56", "57", "58", "59"
+    };
+    static const QByteArray SECOND[] = {
+        "00", "01", "02", "03", "04", "05", "06", "07", "08", "09",
+        "10", "11", "12", "13", "14", "15", "16", "17", "18", "19",
+        "20", "21", "22", "23", "24", "25", "26", "27", "28", "29",
+        "30", "31", "32", "33", "34", "35", "36", "37", "38", "39",
+        "40", "41", "42", "43", "44", "45", "46", "47", "48", "49",
+        "50", "51", "52", "53", "54", "55", "56", "57", "58", "59",
+        "60", "61"  // 0-61 - extra range for leap seconds
+    };
 
     QByteArray utcTime;
+    utcTime.reserve(50);
 
 #if defined(Q_OS_WIN)
     SYSTEMTIME st;
     memset(&st, 0, sizeof(SYSTEMTIME));
     GetSystemTime(&st);
-    utcTime += DAY[st.wDayOfWeek];
-    utcTime += QByteArray::number(st.wDay).rightJustified(2, '0');
+    utcTime += DAY_OF_WEEK[st.wDayOfWeek];
+    utcTime += DAY_OF_MONTH[st.wDay - 1];
     utcTime += ' ';
     utcTime += MONTH[st.wMonth - 1];
     utcTime += QByteArray::number(st.wYear);
     utcTime += ' ';
-    utcTime += QByteArray::number(st.wHour).rightJustified(2, '0');
+    utcTime += HOUR[st.wHour];
     utcTime += ':';
-    utcTime += QByteArray::number(st.wMinute).rightJustified(2, '0');
+    utcTime += MINUTE[st.wMinute];
     utcTime += ':';
-    utcTime += QByteArray::number(st.wSecond).rightJustified(2, '0');
+    utcTime += SECOND[st.wSecond];
     utcTime += " GMT";
 #elif defined(Q_OS_UNIX)
     time_t gtime = 0;
-    tm *t = 0;
+    tm *t = nullptr;
     time(&gtime);
 #if defined(_POSIX_THREAD_SAFE_FUNCTIONS)
     tzset();
@@ -462,17 +495,17 @@ QByteArray THttpUtility::getUTCTimeString()
 #else
     t = gmtime(&gtime);
 #endif  // _POSIX_THREAD_SAFE_FUNCTIONS
-    utcTime += DAY[t->tm_wday];
-    utcTime += QByteArray::number(t->tm_mday).rightJustified(2, '0');
+    utcTime += DAY_OF_WEEK[t->tm_wday];
+    utcTime += DAY_OF_MONTH[t->tm_mday - 1];
     utcTime += ' ';
     utcTime += MONTH[t->tm_mon];
     utcTime += QByteArray::number(t->tm_year + 1900);
     utcTime += ' ';
-    utcTime += QByteArray::number(t->tm_hour).rightJustified(2, '0');
+    utcTime += HOUR[t->tm_hour];
     utcTime += ':';
-    utcTime += QByteArray::number(t->tm_min).rightJustified(2, '0');
+    utcTime += MINUTE[t->tm_min];
     utcTime += ':';
-    utcTime += QByteArray::number(t->tm_sec).rightJustified(2, '0');
+    utcTime += SECOND[t->tm_sec];
     utcTime += " GMT";
 #endif  // Q_OS_UNIX
 

--- a/src/tinternetmessageheader.cpp
+++ b/src/tinternetmessageheader.cpp
@@ -65,6 +65,7 @@ QByteArray TInternetMessageHeader::rawHeader(const QByteArray &key) const
 QByteArrayList TInternetMessageHeader::rawHeaderList() const
 {
     QByteArrayList list;
+    list.reserve(headerPairList.size());
     for (const auto &p : headerPairList) {
         list << p.first;
     }
@@ -113,7 +114,7 @@ void TInternetMessageHeader::addRawHeader(const QByteArray &key, const QByteArra
 */
 QByteArray TInternetMessageHeader::contentType() const
 {
-    return rawHeader("Content-Type");
+    return rawHeader(QByteArrayLiteral("Content-Type"));
 }
 
 /*!
@@ -121,7 +122,7 @@ QByteArray TInternetMessageHeader::contentType() const
 */
 void TInternetMessageHeader::setContentType(const QByteArray &type)
 {
-    setRawHeader("Content-Type", type);
+    setRawHeader(QByteArrayLiteral("Content-Type"), type);
 }
 
 /*!
@@ -129,7 +130,7 @@ void TInternetMessageHeader::setContentType(const QByteArray &type)
 */
 qint64 TInternetMessageHeader::contentLength() const
 {
-    return rawHeader("Content-Length").toLongLong();
+    return rawHeader(QByteArrayLiteral("Content-Length")).toLongLong();
 }
 
 /*!
@@ -137,7 +138,7 @@ qint64 TInternetMessageHeader::contentLength() const
 */
 void TInternetMessageHeader::setContentLength(qint64 len)
 {
-    setRawHeader("Content-Length", QByteArray::number(len));
+    setRawHeader(QByteArrayLiteral("Content-Length"), QByteArray::number(len));
 }
 
 /*!
@@ -145,7 +146,7 @@ void TInternetMessageHeader::setContentLength(qint64 len)
 */
 QByteArray TInternetMessageHeader::date() const
 {
-    return rawHeader("Date");
+    return rawHeader(QByteArrayLiteral("Date"));
 }
 
 /*!
@@ -153,7 +154,7 @@ QByteArray TInternetMessageHeader::date() const
 */
 void TInternetMessageHeader::setDate(const QByteArray &date)
 {
-    setRawHeader("Date", date);
+    setRawHeader(QByteArrayLiteral("Date"), date);
 }
 
 /*!
@@ -170,7 +171,7 @@ void TInternetMessageHeader::setCurrentDate()
 */
 void TInternetMessageHeader::setDate(const QDateTime &dateTime)
 {
-    setRawHeader("Date", THttpUtility::toHttpDateTimeString(dateTime));
+    setRawHeader(QByteArrayLiteral("Date"), THttpUtility::toHttpDateTimeString(dateTime));
 }
 
 /*!
@@ -179,7 +180,7 @@ void TInternetMessageHeader::setDate(const QDateTime &dateTime)
 */
 // void TInternetMessageHeader::setDateUTC(const QDateTime &utc)
 // {
-//     setRawHeader("Date", THttpUtility::toHttpDateTimeUTCString(utc));
+//     setRawHeader(QByteArrayLiteral("Date"), THttpUtility::toHttpDateTimeUTCString(utc));
 // }
 
 /*!
@@ -188,6 +189,7 @@ void TInternetMessageHeader::setDate(const QDateTime &dateTime)
 QByteArray TInternetMessageHeader::toByteArray() const
 {
     QByteArray res;
+    res.reserve(headerPairList.size() * 60);
     for (const auto &p : headerPairList) {
         res += p.first;
         res += ": ";


### PR DESCRIPTION
I also noticed that the request header is parsed twice, first in the THttpSocket::readRequest() function and then in THttpRequest::generate(). Improving this would speed up the handling of requests a bit, but it would require more changes, and I didn't want to break anything.
